### PR TITLE
[Critical] Bug when model want to purge multi tags and key lose before send to delete.

### DIFF
--- a/src/Spiritix/LadaCache/Invalidator.php
+++ b/src/Spiritix/LadaCache/Invalidator.php
@@ -70,7 +70,7 @@ class Invalidator
                 continue;
             }
 
-            $hashes += $this->redis->smembers($tag);
+            $hashes = array_merge($hashes, $this->redis->smembers($tag));
         }
 
         return array_unique($hashes);

--- a/tests/InvalidatorTest.php
+++ b/tests/InvalidatorTest.php
@@ -24,4 +24,14 @@ class InvalidatorTest extends TestCase
 
         $this->assertFalse($this->cache->has('key'));
     }
+
+    public function testInvalidateMultiTags()
+    {
+        $this->cache->set('key1', ['tag1'], 'data');
+        $this->cache->set('key2', ['tag2'], 'data');
+
+        $this->invalidator->invalidate(['tag1', 'tag2']);
+
+        $this->assertFalse($this->cache->has('key2'));
+    }
 }


### PR DESCRIPTION
You can try with simple query like this.
```php
$brands = Brand::paginate(5); // create first cache
$brand = Brand::find(1); // create second cache
$brand2 = Brand::find(1); // get from cache and update
$brand2->update(['name' => 'new name']);

$brand3 = Brand::find(1); // get from cache and we will get old name 
var_dump($brand3->toArray());
```

When you find it later, you will got old name. Read this topic for difference array_merge and plus operator.
http://stackoverflow.com/questions/7059721/array-merge-versus

I test your package many time until find this bug. I don't write this testcase because I work overtime 2 hours. This's up to you.