### PR TITLE
Couple fixes after new commits

### DIFF
--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -30,7 +30,7 @@ return [
     |--------------------------------------------------------------------------
     |
     | By default, if this value is set to null, cached items will never expire.
-    | If you are afraid of death data or if you care about disk space, it may
+    | If you are afraid of dead data or if you care about disk space, it may
     | be a good idea to set this value to something like 604800 (7 days).
     |
     */

--- a/src/Spiritix/LadaCache/Cache.php
+++ b/src/Spiritix/LadaCache/Cache.php
@@ -52,7 +52,7 @@ class Cache
         $this->redis = $redis;
         $this->encoder = $encoder;
 
-        $this->expirationTime = config('lada-cache.active');
+        $this->expirationTime = config('lada-cache.expiration-time');
     }
 
     /**

--- a/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
+++ b/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
@@ -53,6 +53,10 @@ class LadaCacheServiceProvider extends ServiceProvider
         $this->mergeConfigFrom(
             __DIR__ . '/../../../config/' . self::CONFIG_FILE, str_replace('.php', '', self::CONFIG_FILE)
         );
+
+        if (class_exists('Barryvdh\\Debugbar\\LaravelDebugbar')) {
+            $this->registerDebugbarCollector();
+        }
     }
 
     /**
@@ -63,10 +67,6 @@ class LadaCacheServiceProvider extends ServiceProvider
         $this->registerSingletons();
         $this->registerConnections();
         $this->registerCommand();
-
-        if (class_exists('Barryvdh\\Debugbar\\LaravelDebugbar')) {
-            $this->registerDebugbarCollector();
-        }
     }
 
     /**


### PR DESCRIPTION
- Some typo in config

- Wrong config key fetched in Cache.php for cache expiration

- Issue in service provider with debugbar
register() method in service provider is used to register your own stuff and if you reference something different that hasn't been registered yet then you will get error and thus why I moved the registerDebugbarCollector execution to boot() method which is run after all the service providers have run their register method