### PR TITLE
phpredis extension support

### DIFF
--- a/src/Spiritix/LadaCache/Cache.php
+++ b/src/Spiritix/LadaCache/Cache.php
@@ -86,8 +86,14 @@ class Cache
             $this->redis->expire($key, $this->expirationTime);
         }
 
+        $phpredis = extension_loaded('redis');
+
         foreach ($tags as $tag) {
-            $this->redis->sadd($this->redis->prefix($tag), [$key]);
+            if ($phpredis) {
+                $this->redis->sAddArray($this->redis->prefix($tag), [$key]);
+            } else {
+                $this->redis->sadd($this->redis->prefix($tag), [$key]);
+            }
         }
     }
 


### PR DESCRIPTION
I've tried to use phpredis extension with lada-cache instead of Predis, but there is a problem where sadd parameters will not be properly passed to phpredis and on redis-cli monitor i see this

`"SADD" "lada:tags:database:receptes:table:user:row:1" "Array"`
instead of
`"SADD" "lada:tags:database:receptes:table:user:row:1" "lada:90e60daab231709fb94aa8e729d54e51"`