### PR TITLE
Properly register singletons + prefix tags before invalidation (issue 27)

### DIFF
--- a/src/Spiritix/LadaCache/Invalidator.php
+++ b/src/Spiritix/LadaCache/Invalidator.php
@@ -50,6 +50,10 @@ class Invalidator
     {
         $hashes = $this->getHashes($tags);
 
+        foreach ($tags as $tag_index => $tag) {
+            $tags[$tag_index] = $this->redis->prefix($tag);
+        }
+
         $this->deleteItems($hashes);
         $this->deleteItems($tags);
 

--- a/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
+++ b/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
@@ -84,20 +84,20 @@ class LadaCacheServiceProvider extends ServiceProvider
      */
     private function registerSingletons()
     {
-        $redis = new Redis(config('lada-cache.prefix'));
-        $cache = new Cache($redis, new Encoder());
-        $invalidator = new Invalidator($redis);
-
-        $this->app->singleton('lada.cache', function() use ($cache) {
-            return $cache;
+        $this->app->singleton('lada.redis', function ($app) {
+            return new Redis(config('lada-cache.prefix'));
         });
 
-        $this->app->singleton('lada.invalidator', function() use ($invalidator) {
-            return $invalidator;
+        $this->app->singleton('lada.cache', function ($app) {
+            return new Cache($app->make('lada.redis'), new Encoder());
         });
 
-        $this->app->singleton('lada.handler', function() use ($cache, $invalidator) {
-            return new QueryHandler($cache, $invalidator);
+        $this->app->singleton('lada.invalidator', function ($app) {
+            return new Invalidator($app->make('lada.redis'));
+        });
+
+        $this->app->singleton('lada.handler', function ($app) {
+            return new QueryHandler($app->make('lada.cache'), $app->make('lada.invalidator'));
         });
     }
 

--- a/tests/InvalidatorTest.php
+++ b/tests/InvalidatorTest.php
@@ -20,9 +20,12 @@ class InvalidatorTest extends TestCase
     {
         $this->cache->set('key', ['tag1', 'tag4'], 'data');
 
-        $this->invalidator->invalidate(['tag1', 'tag3']);
+        $this->invalidator->invalidate(['tag1', 'tag4']);
 
         $this->assertFalse($this->cache->has('key'));
+
+        $this->assertFalse($this->cache->has('tag1'));
+        $this->assertFalse($this->cache->has('tag4'));
     }
 
     public function testInvalidateMultiTags()
@@ -32,6 +35,10 @@ class InvalidatorTest extends TestCase
 
         $this->invalidator->invalidate(['tag1', 'tag2']);
 
+        $this->assertFalse($this->cache->has('key1'));
         $this->assertFalse($this->cache->has('key2'));
+
+        $this->assertFalse($this->cache->has('tag1'));
+        $this->assertFalse($this->cache->has('tag2'));
     }
 }


### PR DESCRIPTION
Found another bug while working on issue #27 
in service provider the singleton variables were initialized before even registering them which caused the test environment to be ignored (specifically the lada-cache.prefix config variable)
This pull request fixes that and also fixes issue #27 + test case.

We should add some kind of test whether test environment is correct, but I'm not sure where or how to do that, so I didn't attempt to create such test in this pull request.