### PR TITLE
fixed reflector getSql() method

### DIFF
--- a/src/Spiritix/LadaCache/Database/QueryBuilder.php
+++ b/src/Spiritix/LadaCache/Database/QueryBuilder.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Query\Builder;
 use Illuminate\Database\Query\Grammars\Grammar;
 use Illuminate\Database\Query\Processors\Processor;
 use Spiritix\LadaCache\QueryHandler;
+use Spiritix\LadaCache\Reflector;
 
 /**
  * Overrides Laravel's query builder class.
@@ -82,6 +83,8 @@ class QueryBuilder extends Builder
         $result = parent::insert($values);
 
         $this->handler->setBuilder($this)
+            ->setValues($values)
+            ->setSqlOperation('insert')
             ->invalidateQuery('insert');
 
         return $result;
@@ -100,6 +103,8 @@ class QueryBuilder extends Builder
         $result = parent::insertGetId($values, $sequence);
 
         $this->handler->setBuilder($this)
+            ->setValues($values)
+            ->setSqlOperation('insertGetId')
             ->invalidateQuery('insertGetId');
 
         return $result;
@@ -117,6 +122,8 @@ class QueryBuilder extends Builder
         $result = parent::update($values);
 
         $this->handler->setBuilder($this)
+            ->setValues($values)
+            ->setSqlOperation('update')
             ->invalidateQuery('update');
 
         return $result;
@@ -134,6 +141,8 @@ class QueryBuilder extends Builder
         $result = parent::delete($id);
 
         $this->handler->setBuilder($this)
+            ->setValues([Reflector::PRIMARY_KEY_COLUMN => $id])
+            ->setSqlOperation('delete')
             ->invalidateQuery('delete');
 
         return $result;
@@ -147,6 +156,8 @@ class QueryBuilder extends Builder
         parent::truncate();
 
         $this->handler->setBuilder($this)
+            ->setValues([])
+            ->setSqlOperation('truncate')
             ->invalidateQuery('truncate');
     }
 }

--- a/src/Spiritix/LadaCache/QueryHandler.php
+++ b/src/Spiritix/LadaCache/QueryHandler.php
@@ -45,6 +45,20 @@ class QueryHandler
     private $builder = null;
 
     /**
+     * Values to be saved on the model.
+     *
+     * @var array
+     */
+    private $values = [];
+
+    /**
+     * The sql operation being performed.
+     *
+     * @var string
+     */
+    private $sqlOperation = 'select';
+
+    /**
      * Collector instance.
      *
      * @var null|CacheCollector
@@ -73,6 +87,30 @@ class QueryHandler
     public function setBuilder(QueryBuilder $builder)
     {
         $this->builder = $builder;
+
+        return $this;
+    }
+
+    /**
+     * Get values that should be modifier on the model.
+     *
+     * @return array
+     */
+    public function getValues()
+    {
+        return $this->values;
+    }
+
+    /**
+     * Set values to be modifier on the model.
+     *
+     * @param array $values
+     *
+     * @return $this
+     */
+    public function setValues(array $values)
+    {
+        $this->values = $values;
 
         return $this;
     }
@@ -124,6 +162,9 @@ class QueryHandler
 
         $this->destructCollector($reflector, $tagger, $key, $action);
 
+        $this->resetValues();
+        $this->resetSqlOperation();
+
         return $result;
     }
 
@@ -138,6 +179,8 @@ class QueryHandler
 
         /* @var Reflector $reflector */
         $reflector = app()->make(Reflector::class, [$this->builder]);
+        $reflector->setSqlOperation($this->getSqlOperation())
+            ->setValues($this->getValues());
 
         /* @var Tagger $tagger */
         $tagger = app()->make(Tagger::class, [$reflector]);
@@ -146,6 +189,41 @@ class QueryHandler
 
         $action = 'Invalidation (' .  $statementType . ')';
         $this->destructCollector($reflector, $tagger, $hashes, $action);
+
+        $this->resetValues();
+        $this->resetSqlOperation();
+    }
+
+    /**
+     * Resets the sql operation being performed.
+     */
+    public function resetSqlOperation()
+    {
+        $this->sqlOperation = 'select';
+    }
+
+    /**
+     * Get the sql operation being performed.
+     *
+     * @return string
+     */
+    public function getSqlOperation(): string
+    {
+        return $this->sqlOperation;
+    }
+
+    /**
+     * Sets the sql operation.
+     *
+     * @param string $sqlOperation
+     *
+     * @return $this
+     */
+    public function setSqlOperation(string $sqlOperation)
+    {
+        $this->sqlOperation = $sqlOperation;
+
+        return $this;
     }
 
     /**
@@ -185,5 +263,17 @@ class QueryHandler
             $reflector->getSql(),
             $reflector->getParameters()
         );
+    }
+
+    /**
+     * Resets values.
+     *
+     * @return $this
+     */
+    private function resetValues()
+    {
+        $this->values = [];
+
+        return $this;
     }
 }

--- a/src/Spiritix/LadaCache/Reflector.php
+++ b/src/Spiritix/LadaCache/Reflector.php
@@ -38,6 +38,20 @@ class Reflector
     protected $queryBuilder;
 
     /**
+     * Values to be saved on the model.
+     *
+     * @var array
+     */
+    private $values = [];
+
+    /**
+     * The sql operation being performed.
+     *
+     * @var string
+     */
+    private $sqlOperation = 'select';
+
+    /**
      * Initialize reflector.
      *
      * @param QueryBuilder $queryBuilder
@@ -131,7 +145,71 @@ class Reflector
      */
     public function getSql()
     {
-        return $this->queryBuilder->toSql();
+        $compileFunction = $this->getCompileFunction();
+
+        return $this->queryBuilder->getGrammar()->$compileFunction($this->queryBuilder, $this->values);
+    }
+
+    /**
+     * Get the mysql grammar compile function.
+     *
+     * @return string
+     */
+    private function getCompileFunction(): string
+    {
+        switch (strtolower($this->sqlOperation)) {
+            case 'insert':
+                return 'compileInsert';
+            break;
+
+            case 'insertgetid':
+                return 'compileInsertGetId';
+            break;
+
+            case 'update':
+                return 'compileUpdate';
+            break;
+
+            case 'delete':
+                return 'compileDelete';
+            break;
+
+            case 'truncate':
+                return 'compileTruncate';
+            break;
+
+            default:
+                return 'compileSelect';
+            break;
+        }
+    }
+
+    /**
+     * Set values to be modifier on the model.
+     *
+     * @param array $values
+     *
+     * @return $this
+     */
+    public function setValues(array $values)
+    {
+        $this->values = $values;
+
+        return $this;
+    }
+
+    /**
+     * Sets the sql operation.
+     *
+     * @param string $sqlOperation
+     *
+     * @return $this
+     */
+    public function setSqlOperation(string $sqlOperation)
+    {
+        $this->sqlOperation = $sqlOperation;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
fixed an issue in the reflector that would always return a select sql statement in the reflector, even if the sql was an update, insert, delete or truncate statement