### PR TITLE
Cache Invalidation not considering rows in eloquent relations

### DIFF
--- a/src/Spiritix/LadaCache/Tagger.php
+++ b/src/Spiritix/LadaCache/Tagger.php
@@ -95,7 +95,7 @@ class Tagger
             $tags = array_merge($tags, $this->prefix($rows, $this->prefix(self::PREFIX_ROW, $table)));
         }
 
-        if ($this->considerRows === true && !(empty($rows))) {
+        if ($this->considerRows === true && !empty($rows)) {
             return $this->prefix($tags, $database);
         }
 

--- a/src/Spiritix/LadaCache/Tagger.php
+++ b/src/Spiritix/LadaCache/Tagger.php
@@ -95,6 +95,10 @@ class Tagger
             $tags = array_merge($tags, $this->prefix($rows, $this->prefix(self::PREFIX_ROW, $table)));
         }
 
+        if ($this->considerRows === true && !(empty($rows))) {
+            return $this->prefix($tags, $database);
+        }
+
         // Add tables to tags if requested
         if ($this->considerTables) {
             $tags = array_merge($tables, $tags);


### PR DESCRIPTION
The getTags() method will now return tags at the row granularity if required.