### PR TITLE
Initial support for Laravel 5.4

### DIFF
--- a/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
+++ b/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
@@ -85,7 +85,7 @@ class LadaCacheServiceProvider extends ServiceProvider
     private function registerSingletons()
     {
         $this->app->singleton('lada.redis', function($app) {
-            return new Redis(config('lada-cache.prefix'));
+            return new Redis();
         });
 
         $this->app->singleton('lada.cache', function($app) {

--- a/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
+++ b/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
@@ -135,15 +135,15 @@ class LadaCacheServiceProvider extends ServiceProvider
      */
     private function registerCommand()
     {
-        $this->app['command.lada-cache.flush'] = $this->app->share(function() {
+        $this->app->singleton('command.lada-cache.flush', function() {
             return new FlushCommand();
         });
 
-        $this->app['command.lada-cache.enable'] = $this->app->share(function() {
+        $this->app->singleton('command.lada-cache.enable', function() {
             return new EnableCommand();
         });
 
-        $this->app['command.lada-cache.disable'] = $this->app->share(function() {
+        $this->app->singleton('command.lada-cache.disable', function() {
             return new DisableCommand();
         });
 

--- a/src/Spiritix/LadaCache/QueryHandler.php
+++ b/src/Spiritix/LadaCache/QueryHandler.php
@@ -89,10 +89,10 @@ class QueryHandler
         $this->constructCollector();
 
         /* @var Reflector $reflector */
-        $reflector = app()->make(Reflector::class, [$this->builder]);
+        $reflector = new Reflector($this->builder);
 
         /* @var Manager $manager */
-        $manager = app()->make(Manager::class, [$reflector]);
+        $manager = new Manager($reflector);
 
         // If cache is disabled, abort already here to save time
         if (!$manager->shouldCache()) {
@@ -100,10 +100,10 @@ class QueryHandler
         }
 
         /* @var Hasher $hasher */
-        $hasher = app()->make(Hasher::class, [$reflector]);
+        $hasher = new Hasher($reflector);
 
         /* @var Tagger $tagger */
-        $tagger = app()->make(Tagger::class, [$reflector]);
+        $tagger = new Tagger($reflector);
 
         $result = null;
         $key = $hasher->getHash();
@@ -138,10 +138,10 @@ class QueryHandler
         $this->constructCollector();
 
         /* @var Reflector $reflector */
-        $reflector = app()->make(Reflector::class, [$this->builder, $statementType, $values]);
+        $reflector = new Reflector($this->builder, $statementType, $values);
 
         /* @var Tagger $tagger */
-        $tagger = app()->make(Tagger::class, [$reflector]);
+        $tagger = new Tagger($reflector);
 
         $hashes = $this->invalidator->invalidate($tagger->getTags());
 

--- a/src/Spiritix/LadaCache/Redis.php
+++ b/src/Spiritix/LadaCache/Redis.php
@@ -31,11 +31,10 @@ class Redis
     /**
      * Initialize Redis handler.
      *
-     * @param string $prefix
      */
-    public function __construct($prefix)
+    public function __construct()
     {
-        $this->prefix = (string) $prefix;
+        $this->prefix = config('lada-cache.prefix');
     }
 
     /**

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -114,10 +114,10 @@ class IntegrationTest extends TestCase
     private function hasQuery(QueryBuilder $builder)
     {
         /* @var Reflector $reflector */
-        $reflector = app()->make(Reflector::class, [$builder]);
+        $reflector = new Reflector($builder);
 
         /* @var Hasher $hasher */
-        $hasher = app()->make(Hasher::class, [$reflector]);
+        $hasher = new Hasher($reflector);
 
         return $this->cache->has($hasher->getHash());
     }

--- a/tests/TaggerTest.php
+++ b/tests/TaggerTest.php
@@ -611,10 +611,10 @@ class TaggerTest extends TestCase
     private function getTags($tableBuilder, $sqlOperation = Reflector::QUERY_TYPE_SELECT, $values = [])
     {
         /** @var Reflector $reflector */
-        $reflector = app(Reflector::class, [$tableBuilder->getQuery(), $sqlOperation, $values]);
+        $reflector = new Reflector($tableBuilder->getQuery(), $sqlOperation, $values);
 
         /** @var Tagger $tagger */
-        $tagger = app(Tagger::class, [$reflector]);
+        $tagger = new Tagger($reflector);
 
         return $tagger->getTags();
     }


### PR DESCRIPTION
Hello, here is initial support for L5.4.

Scope of changes:
* Replace $app->share() with $app->singleton();
* $app->make() with additional arguments array is not supported anymore, so was replaced with simple class instantiation;
* It was unable to make "lada.redis" service because Laravel tried to find $prefix argument of Redis class in service container when building it and was failing. So this argument was removed and Redis class pulls prefix from config in constructor.