### PR TITLE
Added missing group/tag for config publishing

### DIFF
--- a/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
+++ b/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
@@ -48,7 +48,7 @@ class LadaCacheServiceProvider extends ServiceProvider
     {
         $this->publishes([
             __DIR__ . '/../../../config/' . self::CONFIG_FILE => config_path(self::CONFIG_FILE),
-        ]);
+        ], 'config');
 
         $this->mergeConfigFrom(
             __DIR__ . '/../../../config/' . self::CONFIG_FILE, str_replace('.php', '', self::CONFIG_FILE)


### PR DESCRIPTION
Try deleting your existing lada-cache.php file and then try the command from documentation.
Since it has --tag=config it will not publish the config file.
I've added the missing tag in this merge.