### PR TITLE
Prevent decoding if redis returns null (key does not exist)

### DIFF
--- a/src/Spiritix/LadaCache/Cache.php
+++ b/src/Spiritix/LadaCache/Cache.php
@@ -105,6 +105,11 @@ class Cache
     {
         $encoded = $this->redis->get($this->redis->prefix($key));
 
+        // Prevent decoding if redis returns null (key does not exist).
+        if ($encoded === null) {
+            return null;
+        }
+
         return $this->encoder->decode($encoded);
     }
 


### PR DESCRIPTION
Remember a while ago I reported that we are getting random errors at random times on our production server that seemed to be impossible to reproduce on our local server?

I've finally managed to fix this.

Our redis cache is set to expire keys after 5 minutes and that can create such a scenario where key gets deleted after lada cache issues `exists` command to redis and then issues `get` command expecting to receive string value from redis, but redis returns null, because the key is deleted.

In lada cache the redis `get` statement returned value goes straight to deserialization, so if redis returns `null` that would mean the `get` method would return `false` and thus lada cache considers everything is good and doesn't execute the sql query to get the actual data.


You can debug this by setting breakpoint in [QueryHandler.php](https://github.com/spiritix/lada-cache/blob/e8e87209ebb85b3ec97a194a22262ac5b29937c6/src/Spiritix/LadaCache/QueryHandler.php#L152)
Once breakpoint is hit, delete redis cache and "step into" the `get` statement and you should see that redis returns `null`, but the `get` method will return `false` because of decoding and bypass the check for `null` later in the code at [QueryHandler.php](https://github.com/spiritix/lada-cache/blob/e8e87209ebb85b3ec97a194a22262ac5b29937c6/src/Spiritix/LadaCache/QueryHandler.php#L158)