### PR TITLE
Add support for WhereHas/WhereDoesntHave functionality

### DIFF
--- a/src/Spiritix/LadaCache/Reflector.php
+++ b/src/Spiritix/LadaCache/Reflector.php
@@ -113,7 +113,7 @@ class Reflector
             }
         }
 
-        $this->getTablesFromWhere($this->queryBuilder,$tables);
+        $this->getTablesFromWhere($this->queryBuilder, $tables);
 
         return $tables;
     }

--- a/src/Spiritix/LadaCache/Reflector.php
+++ b/src/Spiritix/LadaCache/Reflector.php
@@ -140,6 +140,8 @@ class Reflector
                         $tables[] = $join->table;
                     }
                 }
+            }
+            if (isset($where['query'])) {
                 $this->getTablesFromWhere($where['query'], $tables);
             }
         }

--- a/src/Spiritix/LadaCache/Reflector.php
+++ b/src/Spiritix/LadaCache/Reflector.php
@@ -113,7 +113,36 @@ class Reflector
             }
         }
 
+        $this->getTablesFromWhere($this->queryBuilder,$tables);
+
         return $tables;
+    }
+
+    /**
+     * Get Table Names From Where Exists, Not Exists (whereHas/whereDoesnthave builder syntax)
+     *
+     * @param QueryBuilder $queryBuilder
+     */
+    private function getTablesFromWhere(QueryBuilder $queryBuilder, &$tables) {
+        if (!isset($queryBuilder->wheres)) {
+            return;
+        }
+        $wheres = $queryBuilder->wheres ?: [];
+        foreach ($wheres as $where) {
+            if ($where['type'] == 'Exists' || $where['type'] == 'NotExists') {
+                $tables[] = $where['query']->from;
+
+                // Add possible join tables
+                $joins = $where['query']->joins ?: [];
+                foreach ($joins as $join) {
+
+                    if (!in_array($join->table, $tables) && is_string($join->table)) {
+                        $tables[] = $join->table;
+                    }
+                }
+                $this->getTablesFromWhere($where['query'], $tables);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
While debugging an issue where the cache wasn't being deleted correctly, I found an issue where the whereHas/whereDoesntHave methods didn't properly delete the associated cache from the tables because the reflector didn't return the tables to tag the cache properly. In the example code:

`$sqlBuilder = $car->whereHas('engine')->select('cars.id');`

Prior to the PR, the only table that the reflector would return is Cars, after it would also return Engine.

Tests have been added for the new code.