### PR TITLE
Upgrade tests and laravel 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ A Redis based, fully automated and scalable database cache layer for Laravel
 [![Latest Unstable Version](https://poser.pugx.org/spiritix/lada-cache/v/unstable.svg)](https://packagist.org/packages/spiritix/lada-cache)
 [![License](https://poser.pugx.org/spiritix/lada-cache/license.svg)](https://packagist.org/packages/spiritix/lada-cache)
 
+_Contributors wanted!
+Since I am running two companies at the moment, my time is very limited. Send me an email if you are interested and I'll be happy to give you an introduction._
+
 ## Table of Contents
 
 - [Features](#features)

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         "illuminate/support": "~5.7|^6.0",
         "illuminate/database": "~5.7|^6.0",
         "illuminate/redis": "~5.7|^6.0",
-        "predis/predis": "~1.0"
+        "predis/predis": "~1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~7.0|^8.0",
         "codeclimate/php-test-reporter": "dev-master",
-        "orchestra/testbench": "~3.7|4.x",
-        "mockery/mockery": "^1.0"
+        "orchestra/testbench": "~3.7|~4.0",
+        "mockery/mockery": "^1.2"
     },
     "suggest": {
         "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol",

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,15 @@
     ],
     "require": {
         "php": ">=7.1",
-        "illuminate/support": "~5.7",
-        "illuminate/database": "~5.7",
-        "illuminate/redis": "~5.7",
+        "illuminate/support": "~5.7|^6.0",
+        "illuminate/database": "~5.7|^6.0",
+        "illuminate/redis": "~5.7|^6.0",
         "predis/predis": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~7.0",
+        "phpunit/phpunit": "~7.0|^8.0",
         "codeclimate/php-test-reporter": "dev-master",
-        "orchestra/testbench": "~3.7",
-        "laracasts/TestDummy": "~2.3",
+        "orchestra/testbench": "~3.7|4.x",
         "mockery/mockery": "^1.0"
     },
     "suggest": {

--- a/database/factories/factories.php
+++ b/database/factories/factories.php
@@ -1,34 +1,42 @@
 <?php
 
+use Faker\Generator as Faker;
 use Spiritix\LadaCache\Tests\Database\Models\Car;
-use Spiritix\LadaCache\Tests\Database\Models\CarMaterial;
 use Spiritix\LadaCache\Tests\Database\Models\Driver;
 use Spiritix\LadaCache\Tests\Database\Models\Engine;
 use Spiritix\LadaCache\Tests\Database\Models\Material;
+use Spiritix\LadaCache\Tests\Database\Models\CarMaterial;
 
-/* @var $factory callable */
-/* @var $faker \Laracasts\TestDummy\FakerAdapter */
-
-$factory(Car::class, [
+$factory->define(Car::class, function (Faker $faker) {
+    return [
     'name' => $faker->word,
     'engine_id' => $faker->randomNumber(8),
     'driver_id' => $faker->randomNumber(8),
-]);
+    ];
+});
 
-$factory(Engine::class, [
-    'name' => $faker->word,
-    'car_id' => $faker->randomNumber(8),
-]);
+$factory->define(Engine::class, function (Faker $faker) {
+    return [
+        'name' => $faker->word,
+        'car_id' => $faker->randomNumber(8),
+    ];
+});
 
-$factory(Driver::class, [
-    'name' => $faker->word,
-]);
+$factory->define(Driver::class, function (Faker $faker) {
+    return [
+        'name' => $faker->word,
+    ];
+});
 
-$factory(Material::class, [
-    'name' => $faker->word,
-]);
+$factory->define(Material::class, function (Faker $faker) {
+    return [
+        'name' => $faker->word,
+    ];
+});
 
-$factory(CarMaterial::class, [
-    'car_id' => $faker->randomNumber(8),
-    'material_id' => $faker->randomNumber(8),
-]);
+$factory->define(CarMaterial::class, function (Faker $faker) {
+    return [
+        'car_id' => $faker->randomNumber(8),
+       'material_id' => $faker->randomNumber(8),
+    ];
+});

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false">
+         >
     <logging>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         >
+         syntaxCheck="false">
     <logging>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/src/Spiritix/LadaCache/Cache.php
+++ b/src/Spiritix/LadaCache/Cache.php
@@ -120,10 +120,11 @@ class Cache
      */
     public function flush()
     {
-        $keys = $this->redis->keys($this->redis->prefix('*'));
+        $prefix = config('database.redis.options.prefix');
+        $keys = $this->redis->scan(null, $prefix . $this->redis->prefix('*'));
 
         foreach ($keys as $key) {
-            $this->redis->del($key);
+            $this->redis->del(str_replace($prefix, '', $key));
         }
     }
 }

--- a/src/Spiritix/LadaCache/Cache.php
+++ b/src/Spiritix/LadaCache/Cache.php
@@ -121,7 +121,7 @@ class Cache
     public function flush()
     {
         $prefix = config('database.redis.options.prefix');
-        $keys = $this->redis->scan(null, $prefix . $this->redis->prefix('*'));
+        $keys = $this->redis->keys($this->redis->prefix('*'));
 
         foreach ($keys as $key) {
             $this->redis->del(str_replace($prefix, '', $key));

--- a/src/Spiritix/LadaCache/QueryHandler.php
+++ b/src/Spiritix/LadaCache/QueryHandler.php
@@ -199,7 +199,7 @@ class QueryHandler
             $this->collector = app()->make('lada.collector');
             $this->collector->startMeasuring();
         }
-        catch (\Illuminate\Contracts\Container\BindingResolutionException $e) {
+        catch (\Exception $e) {
             $this->collector = null;
         }
     }

--- a/src/Spiritix/LadaCache/QueryHandler.php
+++ b/src/Spiritix/LadaCache/QueryHandler.php
@@ -12,8 +12,8 @@
 namespace Spiritix\LadaCache;
 
 use ReflectionException;
-use Spiritix\LadaCache\Database\QueryBuilder;
 use Spiritix\LadaCache\Debug\CacheCollector;
+use Spiritix\LadaCache\Database\QueryBuilder;
 
 /**
  * Query handler is Eloquent's gateway to access the cache.
@@ -199,7 +199,7 @@ class QueryHandler
             $this->collector = app()->make('lada.collector');
             $this->collector->startMeasuring();
         }
-        catch (ReflectionException $e) {
+        catch (\Illuminate\Contracts\Container\BindingResolutionException $e) {
             $this->collector = null;
         }
     }

--- a/src/Spiritix/LadaCache/QueryHandler.php
+++ b/src/Spiritix/LadaCache/QueryHandler.php
@@ -11,7 +11,6 @@
 
 namespace Spiritix\LadaCache;
 
-use ReflectionException;
 use Spiritix\LadaCache\Debug\CacheCollector;
 use Spiritix\LadaCache\Database\QueryBuilder;
 

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -6,7 +6,7 @@ class CacheTest extends TestCase
 {
     private $cache;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/EncoderTest.php
+++ b/tests/EncoderTest.php
@@ -8,7 +8,7 @@ class EncoderTest extends TestCase
 {
     private $encoder;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -17,15 +17,15 @@ class EncoderTest extends TestCase
 
     public function testEncode()
     {
-        $this->assertInternalType('string', $this->encoder->encode(['array']));
-        $this->assertInternalType('string', $this->encoder->encode(5));
-        $this->assertInternalType('string', $this->encoder->encode('string'));
+        $this->assertIsString($this->encoder->encode(['array']));
+        $this->assertIsString($this->encoder->encode(5));
+        $this->assertIsString($this->encoder->encode('string'));
     }
 
     public function testDecode()
     {
-        $this->assertInternalType('array', $this->encoder->decode($this->encoder->encode(['array'])));
-        $this->assertInternalType('int', $this->encoder->decode($this->encoder->encode(5)));
-        $this->assertInternalType('string', $this->encoder->decode($this->encoder->encode('string')));
+        $this->assertIsArray($this->encoder->decode($this->encoder->encode(['array'])));
+        $this->assertIsInt($this->encoder->decode($this->encoder->encode(5)));
+        $this->assertIsString($this->encoder->decode($this->encoder->encode('string')));
     }
 }

--- a/tests/HasherTest.php
+++ b/tests/HasherTest.php
@@ -9,7 +9,7 @@ class HasherTest extends TestCase
 {
     private $hasher;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -18,7 +18,7 @@ class HasherTest extends TestCase
 
     public function testHash()
     {
-        $this->assertInternalType('string', $this->hasher->getHash());
+        $this->assertIsString($this->hasher->getHash());
     }
 
     public function testDatabase()

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -2,16 +2,16 @@
 
 namespace Spiritix\LadaCache\Tests;
 
-use Spiritix\LadaCache\Database\QueryBuilder;
 use Spiritix\LadaCache\Hasher;
 use Spiritix\LadaCache\Reflector;
+use Spiritix\LadaCache\Database\QueryBuilder;
 use Spiritix\LadaCache\Tests\Database\Models\Car;
 
 class IntegrationTest extends TestCase
 {
     private $cache;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -21,7 +21,7 @@ class IntegrationTest extends TestCase
 
     public function testInsert()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         $tableBuilder = Car::where(1, '=', 1);
         $tableBuilder->get();
@@ -44,7 +44,7 @@ class IntegrationTest extends TestCase
 
     public function testUpdate()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         $tableBuilder = Car::where(1, '=', 1);
         $tableBuilder->get();
@@ -70,7 +70,7 @@ class IntegrationTest extends TestCase
 
     public function testDelete()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         $tableBuilder = Car::where(1, '=', 1);
         $tableBuilder->get();
@@ -94,7 +94,7 @@ class IntegrationTest extends TestCase
 
     public function testTruncate()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         $tableBuilder = Car::where(1, '=', 1);
         $tableBuilder->get();

--- a/tests/InvalidatorTest.php
+++ b/tests/InvalidatorTest.php
@@ -8,7 +8,7 @@ class InvalidatorTest extends TestCase
 
     private $invalidator;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/ManagerTest.php
+++ b/tests/ManagerTest.php
@@ -9,7 +9,7 @@ class ManagerTest extends TestCase
 {
     private $stub;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -23,7 +23,7 @@ class RedisTest extends TestCase
 
     public function testCall()
     {
-        $this->expectException('Predis\ClientException');
+        $this->expectException('Error');
 
         $this->redis->doesNotExistInPredis();
     }

--- a/tests/RedisTest.php
+++ b/tests/RedisTest.php
@@ -8,7 +8,7 @@ class RedisTest extends TestCase
 {
     private $redis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TaggerTest.php
+++ b/tests/TaggerTest.php
@@ -2,8 +2,8 @@
 
 namespace Spiritix\LadaCache\Tests;
 
-use Spiritix\LadaCache\Reflector;
 use Spiritix\LadaCache\Tagger;
+use Spiritix\LadaCache\Reflector;
 use Spiritix\LadaCache\Tests\Database\Models\Car;
 use Spiritix\LadaCache\Tests\Database\Models\Engine;
 
@@ -13,7 +13,7 @@ class TaggerTest extends TestCase
 
     private $redis;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class TaggerTest extends TestCase
      */
     public function testSelectWithoutCondition()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -54,7 +54,7 @@ class TaggerTest extends TestCase
      */
     public function testSelectWithUnspecificWhere()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -77,7 +77,7 @@ class TaggerTest extends TestCase
      */
     public function testSelectWithInCondition()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -106,7 +106,7 @@ class TaggerTest extends TestCase
      */
     public function testSelectWithInConditionAndSpecificIdContidionVariant1()
     {
-        $this->factory->times(5)->create(Car::class)
+        factory(Car::class, 5)->create()
             ->each(function ($car) {
                 $engine = app(Engine::class);
                 $engine->name = 'XX';
@@ -147,7 +147,7 @@ class TaggerTest extends TestCase
      */
     public function testSelectWithInConditionAndSpecificIdConditionVariant2()
     {
-        $this->factory->times(5)->create(Car::class)
+        factory(Car::class, 5)->create()
             ->each(function ($car) {
                 $engine = app(Engine::class);
                 $engine->name = 'XX';
@@ -194,7 +194,7 @@ class TaggerTest extends TestCase
      */
     public function testSelectWithJoinAndInConditionAndSpecificIdCondition()
     {
-        $this->factory->times(5)->create(Car::class)
+        factory(Car::class, 5)->create()
             ->each(function ($car) {
                 $engine = app(Engine::class);
                 $engine->name = 'XX';
@@ -244,7 +244,7 @@ class TaggerTest extends TestCase
      */
     public function testSelectWithJoinSub()
     {
-        $this->factory->times(5)->create(Car::class)
+        factory(Car::class, 5)->create()
             ->each(function ($car) {
                 $engine = app(Engine::class);
                 $engine->name = 'XX';
@@ -286,7 +286,7 @@ class TaggerTest extends TestCase
      */
     public function testSelectWithCount()
     {
-        $this->factory->times(5)->create(Car::class)
+        factory(Car::class, 5)->create()
             ->each(function ($car) {
                 $engine = app(Engine::class);
                 $engine->name = 'XX';
@@ -320,7 +320,7 @@ class TaggerTest extends TestCase
      */
     public function testInsertWithoutCondition()
     {
-        $this->factory->times(5)->create(Car::class)
+        factory(Car::class, 5)->create()
             ->each(function ($car) {
                 $engine = app(Engine::class);
                 $engine->name = 'XX';
@@ -362,7 +362,7 @@ class TaggerTest extends TestCase
      */
     public function testUpdateWithUnspecificCondition()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -404,7 +404,7 @@ class TaggerTest extends TestCase
      */
     public function testUpdateWithSpecificIdCondition()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -448,7 +448,7 @@ class TaggerTest extends TestCase
      */
     public function testUpdateWithSpecificInCondition()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -497,7 +497,7 @@ class TaggerTest extends TestCase
      */
     public function testDeleteWithUnspecificCondition()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -536,7 +536,7 @@ class TaggerTest extends TestCase
      */
     public function testDeleteWithSpecificIdCondition()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -576,7 +576,7 @@ class TaggerTest extends TestCase
      */
     public function testDeleteWithSpecificInIdCondition()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);
@@ -621,7 +621,7 @@ class TaggerTest extends TestCase
      */
     public function testTruncate()
     {
-        $this->factory->times(5)->create(Car::class);
+        factory(Car::class, 5)->create();
 
         /** @var Car $car */
         $car = app(Car::class);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,15 +2,13 @@
 
 namespace Spiritix\LadaCache\Tests;
 
-use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\DB;
-use Laracasts\TestDummy\Factory;
+use Illuminate\Foundation\Application;
+use Illuminate\Database\DatabaseServiceProvider;
 use Spiritix\LadaCache\LadaCacheServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    protected $factory;
-
     private $useArtisan;
 
     public function __construct($name = null, array $data = [], $dataName = '')
@@ -20,28 +18,27 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $this->useArtisan = version_compare('5.4', Application::VERSION, '>');
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
         $migrationParams = [
             '--database' => 'testing',
-            '--realpath' => realpath(__DIR__ . '/../database/migrations'),
+            '--path' => realpath(__DIR__.'/../database/migrations'),
+            '--realpath' => true,
         ];
 
         if ($this->useArtisan) {
             $this->artisan('migrate', $migrationParams);
-        }
-        else {
+        } else {
             $this->loadMigrationsFrom($migrationParams);
         }
-
-        $this->factory = new Factory(__DIR__ . '/../database/factories');
-
+        
+        $this->withFactories(realpath(__DIR__.'/../database/factories'));
         DB::beginTransaction();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         DB::rollback();
 


### PR DESCRIPTION
This updates LadaCache to Laravel 6 using the work done by @tof06 but with tests working. Changes are as follows:
1) RedisTest: was failing due to deprecation.
2) Cache.php: flush method for collecting keys was changed to scan as it's less resource intensive on production sites.
```
Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases. 
```
3) Cache.php: Redis automatically adds the options->prefix when preforming a delete. When retrieving the keys, the full key with Redis prefix is returned (i.e. "laravel_database_lada:tag"). This prefix needs to be stripped for deletion to occur.

I added a variable for retrieving the prefix using config() for the scan since Redis doesn't automatically attach the prefix when scanning. There is an issue about this that is years old.