### PR TITLE
Revert "Fixed bug that crashed the app due to unused trait"

### DIFF
--- a/src/Spiritix/LadaCache/Database/QueryBuilder.php
+++ b/src/Spiritix/LadaCache/Database/QueryBuilder.php
@@ -55,7 +55,7 @@ class QueryBuilder extends Builder
         Grammar $grammar,
         Processor $processor,
         QueryHandler $handler,
-        Model $model = null
+        Model $model
     ) {
         parent::__construct($connection, $grammar, $processor);
 


### PR DESCRIPTION
Reverts spiritix/lada-cache#93 due to breaking other things such as relations. Needs better lookout