### PR TITLE
Make LaravelDebug Bar loading optional from config

### DIFF
--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -85,4 +85,14 @@ return [
     */
     'exclude-tables' => [],
 
+    |--------------------------------------------------------------------------
+    | Debugbar Collector
+    |--------------------------------------------------------------------------
+    |
+    | By setting this value to true, we will add a collector for Laravel debugbar.
+    | This may be useful for debugging purposes.
+    |
+    */
+    'enable-debugbar' => env('LADA_CACHE_ENABLE_DEBUGBAR', true),
+
 ];

--- a/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
+++ b/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
@@ -47,7 +47,7 @@ class LadaCacheServiceProvider extends ServiceProvider
             __DIR__ . '/../../../config/' . self::CONFIG_FILE, str_replace('.php', '', self::CONFIG_FILE)
         );
 
-        if ($this->app->bound('debugbar')) {
+        if (config('lada-cache.enable_debugbar') && $this->app->bound('debugbar')) {
             $this->registerDebugbarCollector();
         }
     }

--- a/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
+++ b/src/Spiritix/LadaCache/LadaCacheServiceProvider.php
@@ -47,7 +47,7 @@ class LadaCacheServiceProvider extends ServiceProvider
             __DIR__ . '/../../../config/' . self::CONFIG_FILE, str_replace('.php', '', self::CONFIG_FILE)
         );
 
-        if (config('lada-cache.enable_debugbar') && $this->app->bound('debugbar')) {
+        if (config('lada-cache.enable-debugbar') && $this->app->bound('debugbar')) {
             $this->registerDebugbarCollector();
         }
     }


### PR DESCRIPTION
We have an issue in our company where lada tries to load debug bar (which is disabled for api calls) and runs into problems