### PR TITLE
Type-hint native query builder 🔧

### DIFF
--- a/src/Spiritix/LadaCache/Reflector.php
+++ b/src/Spiritix/LadaCache/Reflector.php
@@ -11,6 +11,7 @@
 
 namespace Spiritix\LadaCache;
 
+use Illuminate\Database\Query\Builder;
 use RuntimeException;
 use Spiritix\LadaCache\Database\QueryBuilder;
 
@@ -121,9 +122,9 @@ class Reflector
     /**
      * Get Table Names From Where Exists, Not Exists (whereHas/whereDoesnthave builder syntax)
      *
-     * @param QueryBuilder $queryBuilder
+     * @param Builder $queryBuilder
      */
-    private function getTablesFromWhere(QueryBuilder $queryBuilder, &$tables) {
+    private function getTablesFromWhere(Builder $queryBuilder, &$tables) {
         if (!isset($queryBuilder->wheres)) {
             return;
         }


### PR DESCRIPTION
## About

We receive errors when using custom query builders with Lada Cache. I figured out it just sends native Query Builder to the `getTablesFromWhere` method. We can type-hint the native one because LadaCache's QueryBuilder extends from it anyways.

---