### PR TITLE
Bugfix: Implement transaction locks in cache invalidate

### DIFF
--- a/tests/InvalidatorTest.php
+++ b/tests/InvalidatorTest.php
@@ -2,10 +2,20 @@
 
 namespace Spiritix\LadaCache\Tests;
 
+use ReflectionClass;
+use Spiritix\LadaCache\Cache;
+use Spiritix\LadaCache\Invalidator;
+
 class InvalidatorTest extends TestCase
 {
+    /**
+     * @var Cache
+     */
     private $cache;
 
+    /**
+     * @var Invalidator
+     */
     private $invalidator;
 
     public function setUp(): void
@@ -14,6 +24,8 @@ class InvalidatorTest extends TestCase
 
         $this->cache = app()->make('lada.cache');
         $this->invalidator = app()->make('lada.invalidator');
+
+        $this->cache->flush();
     }
 
     public function testInvalidate()
@@ -40,5 +52,43 @@ class InvalidatorTest extends TestCase
 
         $this->assertFalse($this->cache->has('tag1'));
         $this->assertFalse($this->cache->has('tag2'));
+    }
+
+    public function testCacheStateWhenInvalideIsCalledInDistributedSystem(): void
+    {
+        // Make reflection class to call private methods.
+        $reflectionClass = new ReflectionClass($this->invalidator);
+        $getHashesAndDeleteTagsFunction = $reflectionClass->getMethod('getHashesAndDeleteTags');
+        $getHashesAndDeleteTagsFunction->setAccessible(true);
+
+        $deleteItemsFunction = $reflectionClass->getMethod('deleteItems');
+        $deleteItemsFunction->setAccessible(true);
+
+        $this->cache->set('key1', ['tag1'], 'data');
+        $this->cache->set('key2', ['tag2'], 'data');
+
+        $tags = ['tag1', 'tag2'];
+
+        // Replicate the functionality of the 'invalidate' function.
+        // Start --------------------------------------------------------------------------------
+        $hashes = $getHashesAndDeleteTagsFunction->invoke($this->invalidator, $tags);
+
+        $this->assertFalse($this->cache->has('tag2'));
+
+        // Simulate distributed system, that adds cache key in the middle of process.
+        // This added cache, has a tag that will be deleted by the first process.
+        $this->cache->set('key3', ['tag2'], 'data');
+
+        $deleteItemsFunction->invoke($this->invalidator, $hashes);
+
+        // End ----------------------------------------------------------------------------------
+
+        $this->assertFalse($this->cache->has('key1'));
+        $this->assertFalse($this->cache->has('key2'));
+        $this->assertFalse($this->cache->has('tag1'));
+
+        // Check key and tag from the simulate distributed system still exists.
+        $this->assertTrue($this->cache->has('key3'));
+        $this->assertTrue($this->cache->has('tag2'));
     }
 }


### PR DESCRIPTION
### Sometimes stale cache never purged in distributed system (race condition)
In bigger systems with a lot of traffic there is a chance that a cache is stuck in the stale state.

---

Bug scenario:

1. User performs query that triggers the invalidation of a model cache on "tag2"
2. Process 1; fetches hashes for a tag "tag2"
3. Another user performs query that triggers caching of data.
4. Process 2; adds cache for "key3", 
5. Process 2; adds additional key "key3" to tag "tag2"
6. Process 1; deletes all hashes it found in tag "tag2"
7. Process 1; deletes cache tag "tag2"

Expected outcome:

- There should be a cache for "key3"
- There should be a cache for "tag2" containing "key3"

Actual outcome:
- There is a cache for "key3"
- There is NOT a cache for "tag2"

Issue:
- This is a problem, because the cache for "key3" will still be used by fetch queries, but going forward calls to invalidate "tag2" does not clear "key3". 
- "key3" cache will say until the cache hits it's expire time.

---

I've tried to add a test that simulates the issue case, but it happens between 2 private method calls, so it's a little hard to write.