### PR TITLE
Bugfix: Validate tags on cache hit

### DIFF
--- a/src/Spiritix/LadaCache/Cache.php
+++ b/src/Spiritix/LadaCache/Cache.php
@@ -91,6 +91,14 @@ class Cache
         }
     }
 
+    public function setCacheTagsForKey($key, array $tags)
+    {
+        $key = $this->redis->prefix($key);
+        foreach ($tags as $tag) {
+            $this->redis->sadd($this->redis->prefix($tag), $key);
+        }
+    }
+
     /**
      * Returns value of a cached key.
      *

--- a/src/Spiritix/LadaCache/Cache.php
+++ b/src/Spiritix/LadaCache/Cache.php
@@ -91,6 +91,15 @@ class Cache
         }
     }
 
+    /**
+     * Store given key in tags.
+     *
+     * Ensure key exists in the given tags.
+     * Redis sets are unique, so the same value will not be added twice.
+     *
+     * @param string $key
+     * @param array $tags
+     */
     public function setCacheTagsForKey($key, array $tags)
     {
         $key = $this->redis->prefix($key);

--- a/src/Spiritix/LadaCache/QueryHandler.php
+++ b/src/Spiritix/LadaCache/QueryHandler.php
@@ -154,10 +154,13 @@ class QueryHandler
 
         $action = ($result === null) ? 'Miss' : 'Hit';
 
-        // If not, execute the query closure and cache the result
         if ($result === null) {
+            // Cache miss, execute the query closure and cache the result
             $result = $queryClosure();
             $this->cache->set($key, $tags, $result);
+        } else {
+            // Cache hit, validate cache tags on key
+            $this->cache->setCacheTagsForKey($key, $tags);
         }
 
         $this->destructCollector($reflector, $tags, $key, $action);

--- a/tests/InvalidatorTest.php
+++ b/tests/InvalidatorTest.php
@@ -91,4 +91,24 @@ class InvalidatorTest extends TestCase
         $this->assertTrue($this->cache->has('key3'));
         $this->assertTrue($this->cache->has('tag2'));
     }
+
+    public function testCacheHitsValidateKeyInTags(): void
+    {
+        $this->cache->set('key1', ['tag2'], 'data'); // <-- Bug, simulate 'tag1' missing from key1
+        $this->cache->set('key2', ['tag1', 'tag2'], 'data');
+
+        // Simulate cache hit on Key1
+        // Start --------------------------------------------------------------------------------
+        $data = $this->cache->get('key1');
+        $this->assertSame('data', $data);
+        $this->cache->setCacheTagsForKey('key1', ['tag1', 'tag2']); // <-- Validate tags for key
+        // End ----------------------------------------------------------------------------------
+
+        // Invalidate cache.
+        $this->invalidator->invalidate(['tag1']);
+
+        // Check cache is invalidated:
+        $this->assertFalse($this->cache->has('key1'));
+        $this->assertFalse($this->cache->has('key2'));
+    }
 }


### PR DESCRIPTION
### Sometimes updates does not invalidate all caches relevant to the model in distributed system (unknown reason)
We are running Lada-cache on a big website with a lot of users.
We can't determine the cause, but sometimes fetch requests, will give us an old (stale) state of the model.

Technically from the code this should be able to happen, if everything works, so I cannot correct any specific file.
But we can see the error state, so we know why we are getting stale caches.

---

Bug state:
- Key1 is cached (tags: Tag1)
- Key2 is cached (tags: Tag1)
- Tag1 has Key2 
- Tag1 does NOT have Key1 (but it's suppose to)
- When an update happens that will clear Tag1, it clears Key2, but it does not clear Key1
- When we fetch Key1 we still get the old cached result
- Invalidating Tag1 will never clear Key1, we have to await for Key1 to expire

Expected state:
- Key1 is cached (tags: Tag1)
- Key2 is cached (tags: Tag1)
- Tag1 has Key2 
- Tag1 HAS Key1 
- When an update happens that will clear Tag1, it clears Key2, and clears Key1
- When we fetch Key1, it will query the database for a fetch result.

---

- The correction in my PR; is that when we get Cache hits, we make sure that the Key is in the tags that they are suppose to be in.
- This does introduce a little performance overhead to cache hits
- Tags are already calculated so the hit comes trying to verify the key is in the required tags.
- The Redis tags are Unique atomic sets, so you cannot add the same key to 1 set. So Redis should have to perform a READ operation for each tag, to check if the Key is in the tag.

Performance on cache hits:
- Performance before : 1x Redis READ
-
- Performance after (tags are correct): 1x Redis READ + (number of tags)x Redis READ 
- Performance after (1 tag is missing): 1x Redis READ + (number of tags)x Redis READ + 1x Redis WRITE

We have currently been running my branch on our production environment for 2 weeks, and it seems to correct the issue completely.
If the performance overhead is a concern, we could also add this as an option to the config and default it to false. That way we don't have any extra overhead for users that don't experience the issue.

```
 'validate-tags-on-cache-hit' => env('LADA_CACHE_VALIDATE_TAGS_ON_CACHE_HIT', false),
```


---

I've tried to add a test that simulates the issue case.