### PR TITLE
Fix an issue where Query Expression throws Exception in Reflector

### DIFF
--- a/src/Spiritix/LadaCache/Reflector.php
+++ b/src/Spiritix/LadaCache/Reflector.php
@@ -11,6 +11,7 @@
 
 namespace Spiritix\LadaCache;
 
+use Illuminate\Database\Query\Expression;
 use RuntimeException;
 use Spiritix\LadaCache\Database\QueryBuilder;
 
@@ -164,12 +165,17 @@ class Reflector
                 continue;
             }
 
+           // Get the value of Query Expression
+            if ($where['column'] instanceof Expression) {
+                $where['column'] = $where['column']->getValue($this->queryBuilder->getGrammar());
+            }
+
             // If it doesn't contain the table name assume it's the "FROM" table
             if (strpos($where['column'], '.') === false) {
                 $where['column'] = implode('.', [$this->queryBuilder->from, $where['column']]);
             }
 
-            list($table, $column) = $this->splitTableAndColumn($where['column']);
+            [$table, $column] = $this->splitTableAndColumn($where['column']);
 
             // Make sure that the where clause applies for the primary key column
             if ($column !== $this->queryBuilder->getPrimaryKeyName()) {


### PR DESCRIPTION
Currently, in the Reflector class, if `$where['column']` is a Query Expression, it's not being accounted for, resulting in an Exception thrown by `strpos($where['column'], '.')`.

```
strpos(): Argument #1 ($haystack) must be of type string, Illuminate\Database\Query\Expression given.
```

```
vendor/spiritix/lada-cache/src/Spiritix/LadaCache/Reflector.php :175

if (strpos($where['column'], '.') === false) {
    $where['column'] = implode('.', [$this->queryBuilder->from, $where['column']]);
}
```

This PR adds an additional check to get the Expression's value pior to using `strpos()`.

---
An example query that causes the problem is as follows. It uses Laravel's `whereHas()` to count the number of related connections. In this case, I need exactly 3.

```php
use Illuminate\Database\Eloquent\Builder;

public function apply(Builder $query): Builder
{
    return $query->whereHas('connections', function (Builder $query): void {
            $query
                ->whereIn('slug', [Connection::Wireless, Connection::Bluetooth, Connection::USBA])
                ->orWhereIn('slug', [Connection::Wireless, Connection::Bluetooth, Connection::USBC]);
        }, '=', '3');
    }
}
```

After adding the check, the query works fine, no more exception and it's get cached as expected.

The final query:

```sql
SELECT 
  * 
FROM 
  `keyboards` 
WHERE 
  (
    SELECT 
      count(*) 
    FROM 
      `connections` 
      INNER JOIN `connection_keyboard` ON `connections`.`id` = `connection_keyboard`.`connection_id` 
    WHERE 
      `keyboards`.`id` = `connection_keyboard`.`keyboard_id` 
      AND (
        `slug` IN ('wireless', 'bluetooth', 'usba') 
        OR `slug` IN ('wireless', 'bluetooth', 'usbc')
      )
  ) = 3
```