### PR TITLE
feat: add withoutCache() for per-query bypass

### DIFF
--- a/src/Database/QueryBuilder.php
+++ b/src/Database/QueryBuilder.php
@@ -25,6 +25,8 @@ class QueryBuilder extends Builder
 
     private readonly ?Model $model;
 
+    private bool $skipCache = false;
+
     public function __construct(
         ConnectionInterface $connection,
         QueryHandler $handler,
@@ -35,6 +37,22 @@ class QueryBuilder extends Builder
         parent::__construct($connection, $grammar, $processor);
         $this->handler = $handler;
         $this->model = $model;
+    }
+
+    /**
+     * Bypass Lada Cache for this single query — both read (no get/set) and write (no invalidation queue).
+     * Useful for diagnostics, freshness-critical reads, and ad-hoc cache busting without touching config.
+     */
+    public function withoutCache(): static
+    {
+        $this->skipCache = true;
+
+        return $this;
+    }
+
+    public function isSkippingCache(): bool
+    {
+        return $this->skipCache;
     }
 
     /** {@inheritDoc} */
@@ -88,7 +106,8 @@ class QueryBuilder extends Builder
     {
         // Do not cache queries that use pessimistic locks (lockForUpdate/sharedLock).
         // Laravel stores lock intent in $this->lock; when present we should always hit the DB.
-        if ($this->lock !== null) {
+        // Also bypass when the caller opted out via withoutCache().
+        if ($this->lock !== null || $this->skipCache) {
             return parent::runSelect();
         }
 
@@ -132,10 +151,7 @@ class QueryBuilder extends Builder
     public function insert(array $values)
     {
         $result = parent::insert($values);
-
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_INSERT, $values);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_INSERT, $values);
 
         return $result;
     }
@@ -144,11 +160,8 @@ class QueryBuilder extends Builder
     public function insertUsing(array $columns, $query)
     {
         $result = parent::insertUsing($columns, $query);
-
         // Treat as INSERT for invalidation.
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_INSERT, []);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_INSERT);
 
         return $result;
     }
@@ -157,11 +170,8 @@ class QueryBuilder extends Builder
     public function insertOrIgnoreUsing(array $columns, $query)
     {
         $result = parent::insertOrIgnoreUsing($columns, $query);
-
         // May still insert rows; invalidate conservatively as INSERT.
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_INSERT, []);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_INSERT);
 
         return $result;
     }
@@ -170,11 +180,8 @@ class QueryBuilder extends Builder
     public function updateFrom(array $values)
     {
         $result = parent::updateFrom($values);
-
         // Update-from modifies rows; invalidate as UPDATE.
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_UPDATE, $values);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_UPDATE, $values);
 
         return $result;
     }
@@ -183,10 +190,7 @@ class QueryBuilder extends Builder
     public function insertGetId(array $values, $sequence = null)
     {
         $id = parent::insertGetId($values, $sequence);
-
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_INSERT, $values);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_INSERT, $values);
 
         return $id;
     }
@@ -195,10 +199,7 @@ class QueryBuilder extends Builder
     public function update(array $values)
     {
         $count = parent::update($values);
-
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_UPDATE, $values);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_UPDATE, $values);
 
         return $count;
     }
@@ -207,11 +208,8 @@ class QueryBuilder extends Builder
     public function upsert(array $values, $uniqueBy, $update = null)
     {
         $result = parent::upsert($values, $uniqueBy, $update);
-
         // Treat UPSERT as an UPDATE-like invalidation to safely clear unspecific table tags.
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_UPDATE, is_array($values) ? (array) $values : []);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_UPDATE, is_array($values) ? (array) $values : []);
 
         return $result;
     }
@@ -220,11 +218,8 @@ class QueryBuilder extends Builder
     public function insertOrIgnore(array $values)
     {
         $result = parent::insertOrIgnore($values);
-
         // Insert-or-ignore may still insert rows; invalidate as INSERT.
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_INSERT, $values);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_INSERT, $values);
 
         return $result;
     }
@@ -233,11 +228,8 @@ class QueryBuilder extends Builder
     public function updateOrInsert(array $attributes, callable|array $values = [])
     {
         $result = parent::updateOrInsert($attributes, $values);
-
         // May perform insert or update; invalidate conservatively as UPDATE.
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_UPDATE, $values ?: $attributes);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_UPDATE, $values ?: $attributes);
 
         return $result;
     }
@@ -246,12 +238,7 @@ class QueryBuilder extends Builder
     public function delete($id = null)
     {
         $count = parent::delete($id);
-
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_DELETE, [
-                $this->getPrimaryKeyName() => $id,
-            ]);
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_DELETE, [$this->getPrimaryKeyName() => $id]);
 
         return $count;
     }
@@ -260,9 +247,26 @@ class QueryBuilder extends Builder
     public function truncate()
     {
         parent::truncate();
+        $this->invalidateUnlessSkipped(Reflector::QUERY_TYPE_TRUNCATE);
+    }
 
-        $this->handler
-            ->setBuilder($this)
-            ->invalidateQuery(Reflector::QUERY_TYPE_TRUNCATE);
+    /**
+     * Invalidate cache for the current query unless withoutCache() was called.
+     *
+     * Called from every mutation override (insert/update/delete/upsert/truncate variants)
+     * after the parent operation completes. The skipCache guard lets withoutCache()
+     * suppress both read caching and invalidation queueing from one place.
+     *
+     * Exception safety: callers invoke this AFTER parent::method(), so a thrown
+     * mutation aborts before reaching invalidation — a failed mutation does not
+     * invalidate the cache.
+     */
+    private function invalidateUnlessSkipped(string $queryType, array $values = []): void
+    {
+        if ($this->skipCache) {
+            return;
+        }
+
+        $this->handler->setBuilder($this)->invalidateQuery($queryType, $values);
     }
 }

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiritix\LadaCache;
 
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionRolledBack;
@@ -16,6 +17,7 @@ use Spiritix\LadaCache\Console\FlushCommand;
 use Spiritix\LadaCache\Database\MySqlConnection as LadaMySqlConnection;
 use Spiritix\LadaCache\Database\MariaDbConnection as LadaMariaDbConnection;
 use Spiritix\LadaCache\Database\PostgresConnection as LadaPostgresConnection;
+use Spiritix\LadaCache\Database\QueryBuilder;
 use Spiritix\LadaCache\Database\SqliteConnection as LadaSqliteConnection;
 use Spiritix\LadaCache\Database\SqlServerConnection as LadaSqlServerConnection;
 use Spiritix\LadaCache\Debug\CacheCollector;
@@ -36,6 +38,21 @@ final class LadaCacheServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/'.self::CONFIG_FILE => config_path(self::CONFIG_FILE),
         ], 'config');
+
+        // Eloquent macro: propagate withoutCache() from Eloquent builder to the underlying Lada QueryBuilder.
+        // Registered BEFORE the active-cache guard so the macro stays available even when Lada is disabled —
+        // in that case the underlying query is a vanilla Laravel Builder (not our QueryBuilder), the instanceof
+        // check fails, and the call becomes a graceful no-op instead of throwing BadMethodCallException.
+        EloquentBuilder::macro('withoutCache', function () {
+            /** @var EloquentBuilder $this */
+            $query = $this->getQuery();
+
+            if ($query instanceof QueryBuilder) {
+                $query->withoutCache();
+            }
+
+            return $this;
+        });
 
         // If Lada Cache is not active, avoid wiring listeners / debugbar that could resolve Redis.
         if (! (bool) config('lada-cache.active', true)) {

--- a/tests/Integration/QueryBuilder/WithoutCacheTest.php
+++ b/tests/Integration/QueryBuilder/WithoutCacheTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Integration\QueryBuilder;
+
+use Illuminate\Support\Facades\DB;
+use Spiritix\LadaCache\Database\QueryBuilder;
+use Spiritix\LadaCache\Hasher;
+use Spiritix\LadaCache\Reflector;
+use Spiritix\LadaCache\Tests\Concerns\CacheAssertions;
+use Spiritix\LadaCache\Tests\Database\Models\Car;
+use Spiritix\LadaCache\Tests\TestCase;
+
+class WithoutCacheTest extends TestCase
+{
+    use CacheAssertions;
+
+    public function testWithoutCacheBypassesReadCache(): void
+    {
+        DB::table('cars')->insert(['id' => 10, 'name' => 'NoCacheRead', 'engine_id' => null, 'driver_id' => null]);
+
+        $builder = DB::table('cars')->where('id', 10);
+
+        // First read with withoutCache should NOT populate cache
+        $result = $builder->withoutCache()->get();
+        $this->assertNotEmpty($result);
+
+        $key = (new Hasher(new Reflector($builder)))->getHash();
+        $this->assertCacheMissing($key, 'withoutCache should not populate Redis on read');
+    }
+
+    public function testWithoutCacheBypassesWriteInvalidation(): void
+    {
+        // Arrange: warm cache for the cars table
+        DB::table('cars')->insert(['id' => 20, 'name' => 'OriginalName', 'engine_id' => null, 'driver_id' => null]);
+        $builder = DB::table('cars')->where('id', 20);
+        $first = $builder->get();
+        $this->assertNotEmpty($first);
+
+        $key = (new Hasher(new Reflector($builder)))->getHash();
+        $this->assertCacheHas($key, 'Read should populate the cache');
+
+        // Act: write with withoutCache — invalidation must NOT fire
+        DB::table('cars')->where('id', 20)->withoutCache()->update(['name' => 'WithoutCacheWrite']);
+
+        // Assert: cache still has the (now-stale) key because invalidation was skipped
+        $this->assertCacheHas($key, 'withoutCache write must not queue/fire invalidation');
+    }
+
+    public function testNormalWriteStillInvalidates(): void
+    {
+        // Sanity check that regression of withoutCache did not break default behavior
+        DB::table('cars')->insert(['id' => 30, 'name' => 'NormalWriteOriginal', 'engine_id' => null, 'driver_id' => null]);
+        $builder = DB::table('cars')->where('id', 30);
+        $builder->get();
+
+        $key = (new Hasher(new Reflector($builder)))->getHash();
+        $this->assertCacheHas($key);
+
+        DB::table('cars')->where('id', 30)->update(['name' => 'NormalWriteAfter']);
+
+        $this->assertCacheMissing($key, 'Default write path must invalidate');
+    }
+
+    public function testWithoutCacheReturnsBuilderForChaining(): void
+    {
+        $builder = DB::table('cars');
+        $returned = $builder->withoutCache();
+
+        $this->assertInstanceOf(QueryBuilder::class, $returned);
+        $this->assertTrue($returned->isSkippingCache());
+    }
+
+    public function testEloquentMacroPropagatesToUnderlyingQueryBuilder(): void
+    {
+        Car::query()->forceCreate(['id' => 40, 'name' => 'EloquentMacro', 'engine_id' => null, 'driver_id' => null]);
+
+        $eloquent = Car::query()->where('id', 40);
+        $eloquent->withoutCache(); // Eloquent macro
+        $underlying = $eloquent->getQuery();
+
+        $this->assertInstanceOf(QueryBuilder::class, $underlying);
+        $this->assertTrue($underlying->isSkippingCache(), 'Eloquent macro must flip the underlying QueryBuilder skipCache flag');
+    }
+
+    public function testChainOrderingPreservesSkipFlag(): void
+    {
+        DB::table('cars')->insert(['id' => 50, 'name' => 'ChainOrder', 'engine_id' => null, 'driver_id' => null]);
+
+        // withoutCache before where()
+        $builderA = DB::table('cars')->withoutCache()->where('id', 50);
+        $builderA->get();
+        $keyA = (new Hasher(new Reflector($builderA)))->getHash();
+        $this->assertCacheMissing($keyA, 'withoutCache->where chain must bypass');
+
+        // where() before withoutCache
+        $builderB = DB::table('cars')->where('id', 50)->withoutCache();
+        $builderB->get();
+        $keyB = (new Hasher(new Reflector($builderB)))->getHash();
+        $this->assertCacheMissing($keyB, 'where->withoutCache chain must bypass');
+    }
+}


### PR DESCRIPTION
## Summary

Adds a fluent escape hatch to skip Lada Cache on individual queries — covers both the **read** path (`runSelect` get/set) and the **write** path (invalidation queue).

```php
// Read fresh, don't populate cache
User::query()->withoutCache()->where('status', 'active')->get();

// Write without triggering invalidation cascade (diagnostics, ad-hoc cleanup)
DB::table('posts')->withoutCache()->where('id', 42)->update(['views' => 0]);
```

## What changed

- `QueryBuilder::withoutCache(): static` — flips a per-instance `$skipCache` flag
- `runSelect()` — returns parent implementation when the flag is set (matches existing `lockForUpdate` bypass behavior)
- New private helper `invalidateUnlessSkipped(type, values): void` — every mutation override (`insert`, `insertUsing`, `insertOrIgnoreUsing`, `updateFrom`, `insertGetId`, `update`, `upsert`, `insertOrIgnore`, `updateOrInsert`, `delete`, `truncate`) calls it after `parent::method()`. The flag suppresses BOTH read caching and invalidation queueing from one consistent place.
- Eloquent macro `Builder::withoutCache()` — propagates to the underlying `QueryBuilder` via `getQuery()`; registered BEFORE the active-cache guard so it becomes a graceful no-op when Lada is disabled (no `BadMethodCallException`)

## Design notes

**Post-hook helper (not a template wrapper).** Each mutation override is a 3-line `parent::call() → helper() → return` sequence. The helper name accurately reflects what it does — skip OR invalidate — instead of claiming to always invalidate. No closure allocation per call, no extra indirection. If a future cross-cutting concern (metrics, tracing) genuinely needs a wrapper, it can be promoted then; YAGNI for now.

**Exception safety.** The helper is called AFTER `parent::method()`, so a thrown mutation aborts before invalidation — a failed mutation does not invalidate the cache. Matches prior per-method behavior.

## Motivation

We hit three real situations in production where this was needed:

1. **Diagnostics** — read fresh DB state to compare against cached values when investigating staleness, without polluting the cache
2. **Maintenance scripts** — bulk updates where we don't want a tag-flush cascade (the script flushes manually at the end)
3. **Freshness-critical reads** — payment confirmation reads inside a tight workflow where 5ms savings matter less than reading post-commit state

Before this change, the only options were `Cache::disable()` (process-wide), config edits, or routing through a non-Lada connection — all heavyweight and easy to forget to revert.

## Tests

6 integration tests in `tests/Integration/QueryBuilder/WithoutCacheTest.php`:
- Read bypass (cache not populated)
- Write bypass (invalidation not triggered)
- Default write path still invalidates (regression guard)
- Builder returned for chaining + `isSkippingCache()` accessor
- Eloquent macro propagates to underlying QueryBuilder
- Chain ordering independence (`withoutCache()->where()` vs `where()->withoutCache()`)

## Compatibility / edge cases

- No public API breaks. Only additive: one new method + one Eloquent macro.
- Macro registration is idempotent across Octane worker boots.
- When Lada is disabled (`config('lada-cache.active', false)`), the macro instanceof check returns false and the call is a no-op — no exception.
- Flag is per-instance (not static), each `Model::query()` creates a fresh `QueryBuilder` so there is no cross-request leak in Octane.
- **Pre-existing transaction edge case**: if a mutation runs inside a transaction that later rolls back, the cache is still invalidated (because invalidation is queued and flushed at the connection-level `TransactionCommitted` listener, but the per-method invalidation queue is built immediately). This is not introduced by this PR — flagging it as a known limitation worth a follow-up.