### PR TITLE
feat: add per-model TTL via HasLadaTtl interface

### DIFF
--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -67,6 +67,30 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Per-model TTL overrides
+    |--------------------------------------------------------------------------
+    |
+    | Map of model FQCN to TTL in seconds. Models listed here override the
+    | global expiration_time. Resolution order (first non-null wins):
+    |   1. $model->getLadaTtl() if model implements
+    |      Spiritix\LadaCache\Contracts\HasLadaTtl
+    |   2. config('lada-cache.model_ttls.<FQCN>')
+    |   3. config('lada-cache.expiration_time') (global)
+    |
+    | Examples:
+    |   App\Models\City::class       => 86400 * 30, // 30 days for rarely-changing data
+    |   App\Models\Tournament::class => 300,        // 5 minutes for hot state
+    |   App\Models\Order::class      => null,       // fall through to global
+    |
+    | 0 = persist forever (cache until tag-based invalidation).
+    |
+    */
+    'model_ttls' => [
+        // App\Models\City::class => 86400 * 30,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Granularity
     |--------------------------------------------------------------------------
     |

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -36,13 +36,24 @@ final class Cache
         return (bool) $this->redis->exists($this->redis->prefix($key));
     }
 
-    public function set(string $key, array $tags, mixed $data): void
+    /**
+     * Persist a cached query result under the given key with optional per-call TTL.
+     *
+     * TTL resolution:
+     *   - $ttl > 0  : SET key value EX $ttl (expires after $ttl seconds)
+     *   - $ttl = 0  : SET key value (no expiration — persist forever, rely on tag invalidation)
+     *   - $ttl null : fall back to the global expirationTime (which itself follows the same > 0 / = 0 rule)
+     *
+     * @param array<string> $tags
+     */
+    public function set(string $key, array $tags, mixed $data, ?int $ttl = null): void
     {
         $key = $this->redis->prefix($key);
         $value = $this->encoder->encode($data);
+        $effectiveTtl = $ttl ?? $this->expirationTime;
 
-        if ($this->expirationTime > 0) {
-            $this->redis->set($key, $value, 'EX', $this->expirationTime);
+        if ($effectiveTtl > 0) {
+            $this->redis->set($key, $value, 'EX', $effectiveTtl);
         } else {
             $this->redis->set($key, $value);
         }

--- a/src/Contracts/HasLadaTtl.php
+++ b/src/Contracts/HasLadaTtl.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Contracts;
+
+/**
+ * Marker interface for Eloquent models that want to override the default Lada Cache TTL.
+ *
+ * Implementing this on a model lets the cache layer apply a per-model TTL instead of
+ * the global config('lada-cache.expiration_time'). Resolution order is:
+ *   1. Model::getLadaTtl() (this interface)
+ *   2. config('lada-cache.model_ttls.<ClassName>')
+ *   3. global config('lada-cache.expiration_time')
+ *
+ * Semantics of the returned value:
+ *   - null : defer to config-level fallback (model_ttls or global)
+ *   - > 0  : TTL in seconds (e.g., 3600 = 1 hour)
+ *   - 0    : persist forever (cache until tag-based invalidation) — same as
+ *            setting global expiration_time to 0
+ *   - < 0  : same as 0 (forever) — discouraged, prefer 0
+ */
+interface HasLadaTtl
+{
+    public function getLadaTtl(): ?int;
+}

--- a/src/Contracts/HasLadaTtl.php
+++ b/src/Contracts/HasLadaTtl.php
@@ -13,6 +13,18 @@ namespace Spiritix\LadaCache\Contracts;
  *   2. config('lada-cache.model_ttls.<ClassName>')
  *   3. global config('lada-cache.expiration_time')
  *
+ * Easiest way to opt in is via `LadaCacheTrait`, which already provides a
+ * default `getLadaTtl()` implementation reading from a `public ?int $ladaTtl`
+ * property declared on the model:
+ *
+ *     class City extends Model implements HasLadaTtl
+ *     {
+ *         use LadaCacheTrait;
+ *         public ?int $ladaTtl = 86400 * 30; // 30 days
+ *     }
+ *
+ * Override the method only when dynamic TTL logic is required.
+ *
  * Semantics of the returned value:
  *   - null : defer to config-level fallback (model_ttls or global)
  *   - > 0  : TTL in seconds (e.g., 3600 = 1 hour)

--- a/src/Database/LadaCacheTrait.php
+++ b/src/Database/LadaCacheTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiritix\LadaCache\Database;
 
+use ReflectionProperty;
 use Spiritix\LadaCache\QueryHandler;
 
 /**
@@ -12,9 +13,51 @@ use Spiritix\LadaCache\QueryHandler;
  * Include this trait on models to route all base queries through the
  * Lada Cache-aware query builder, enabling transparent caching and
  * invalidation.
+ *
+ * Easiest way to override the TTL for a model:
+ *
+ *     class City extends Model implements HasLadaTtl
+ *     {
+ *         use LadaCacheTrait;
+ *         public ?int $ladaTtl = 86400 * 30; // 30 days
+ *     }
+ *
+ * Override `getLadaTtl()` only when dynamic logic is required. If the model
+ * cannot be edited, fall back to `config('lada-cache.model_ttls.<FQCN>')`.
  */
 trait LadaCacheTrait
 {
+    /**
+     * Default implementation of {@see \Spiritix\LadaCache\Contracts\HasLadaTtl::getLadaTtl()}.
+     *
+     * Reads an optional `public ?int $ladaTtl` property declared on the model.
+     * Models only need to declare the property; method override is reserved
+     * for cases that require dynamic TTL logic.
+     *
+     * The property is intentionally NOT declared on the trait itself. PHP does
+     * not allow a subclass to redeclare a trait-provided property with a
+     * different default (fatal error: incompatible composition), so the trait
+     * supplies only the method and lets the model own the property.
+     */
+    public function getLadaTtl(): ?int
+    {
+        if (! property_exists($this, 'ladaTtl')) {
+            return null;
+        }
+
+        // A typed property declared without a default value (`public ?int $ladaTtl;`)
+        // throws Error("must not be accessed before initialization") on direct read.
+        // Guard with Reflection to avoid the crash and fall back to config resolution.
+        if (! (new ReflectionProperty($this, 'ladaTtl'))->isInitialized($this)) {
+            return null;
+        }
+
+        /** @var int|null $ttl */
+        $ttl = $this->ladaTtl;
+
+        return $ttl;
+    }
+
     /** {@inheritDoc} */
     protected function newBaseQueryBuilder()
     {

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -95,6 +95,7 @@ final class LadaCacheServiceProvider extends ServiceProvider
             'lada.redis',
             'lada.cache',
             'lada.invalidator',
+            'lada.ttl_resolver',
             'lada.handler',
         ];
     }
@@ -109,8 +110,13 @@ final class LadaCacheServiceProvider extends ServiceProvider
         $this->app->singleton('lada.invalidator', static fn (Application $app) => new Invalidator($app->make('lada.redis'))
         );
 
-        $this->app->singleton('lada.handler', static fn (Application $app) => new QueryHandler($app->make('lada.cache'), $app->make('lada.invalidator'))
-        );
+        $this->app->singleton('lada.ttl_resolver', static fn () => new TtlResolver);
+
+        $this->app->singleton('lada.handler', static fn (Application $app) => new QueryHandler(
+            $app->make('lada.cache'),
+            $app->make('lada.invalidator'),
+            $app->make('lada.ttl_resolver'),
+        ));
     }
 
     /**

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -35,6 +35,7 @@ final class QueryHandler
     public function __construct(
         private readonly Cache $cache,
         private readonly Invalidator $invalidator,
+        private readonly TtlResolver $ttlResolver,
     ) {}
 
     public function setBuilder(QueryBuilder $builder): self
@@ -156,7 +157,8 @@ final class QueryHandler
 
             if ($cached === null) {
                 $cached = $queryClosure();
-                $this->cache->set($key, $tags, $cached);
+                $ttl = $this->ttlResolver->resolve($this->builder->getModel());
+                $this->cache->set($key, $tags, $cached, $ttl);
             } else {
                 // Self-heal tag membership inconsistencies by idempotently adding the key to each tag set.
                 $this->cache->repairTagMembership($key, $tags);

--- a/src/TtlResolver.php
+++ b/src/TtlResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache;
+
+use Illuminate\Database\Eloquent\Model;
+use Spiritix\LadaCache\Contracts\HasLadaTtl;
+
+/**
+ * Resolves the effective Lada Cache TTL for a given Eloquent model.
+ *
+ * Resolution order (first non-null wins):
+ *   1. Model implements HasLadaTtl → $model->getLadaTtl()
+ *   2. config('lada-cache.model_ttls.<FQCN>')
+ *   3. null → caller defers to global config('lada-cache.expiration_time')
+ *
+ * Octane-safe: no mutable state, config is read once at construction.
+ */
+final class TtlResolver
+{
+    /** @var array<class-string, ?int> */
+    private readonly array $modelTtls;
+
+    public function __construct()
+    {
+        /** @var array<class-string, ?int> $configured */
+        $configured = (array) config('lada-cache.model_ttls', []);
+        $this->modelTtls = $configured;
+    }
+
+    public function resolve(?Model $model): ?int
+    {
+        if ($model === null) {
+            return null;
+        }
+
+        if ($model instanceof HasLadaTtl) {
+            $ttl = $model->getLadaTtl();
+
+            if ($ttl !== null) {
+                return $ttl;
+            }
+        }
+
+        return $this->modelTtls[$model::class] ?? null;
+    }
+}

--- a/tests/Integration/Cache/PerModelTtlTest.php
+++ b/tests/Integration/Cache/PerModelTtlTest.php
@@ -7,6 +7,7 @@ namespace Spiritix\LadaCache\Tests\Integration\Cache;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Config;
 use Spiritix\LadaCache\Contracts\HasLadaTtl;
+use Spiritix\LadaCache\Database\LadaCacheTrait;
 use Spiritix\LadaCache\Redis as LadaRedis;
 use Spiritix\LadaCache\Tests\TestCase;
 use Spiritix\LadaCache\TtlResolver;
@@ -63,6 +64,51 @@ class PerModelTtlTest extends TestCase
         $resolver = new TtlResolver();
 
         $this->assertSame(0, $resolver->resolve(new HasTtlZeroFixture()));
+    }
+
+    // ------------------------------------------------------------------
+    // LadaCacheTrait: default getLadaTtl() reads from $ladaTtl property
+    // ------------------------------------------------------------------
+
+    public function testResolveUsesTraitPropertyWhenOnlyPropertySet(): void
+    {
+        $resolver = new TtlResolver();
+
+        // The model only declares `public ?int $ladaTtl = 120;`. The trait's
+        // default getLadaTtl() must read the property and return its value.
+        $this->assertSame(120, $resolver->resolve(new PropertyOnlyTtlFixture()));
+    }
+
+    public function testResolveNullTraitPropertyFallsBackToConfig(): void
+    {
+        Config::set('lada-cache.model_ttls', [PropertyNullTtlFixture::class => 3600]);
+        $resolver = new TtlResolver();
+
+        // Default `$ladaTtl = null` → trait method returns null → config fallback applies.
+        $this->assertSame(3600, $resolver->resolve(new PropertyNullTtlFixture()));
+    }
+
+    public function testResolveFallsBackToConfigWhenInterfaceImplementedButPropertyMissing(): void
+    {
+        Config::set('lada-cache.model_ttls', [PropertyMissingTtlFixture::class => 1234]);
+        $resolver = new TtlResolver();
+
+        // implements HasLadaTtl but `$ladaTtl` is not declared at all —
+        // property_exists() returns false, trait getLadaTtl() returns null,
+        // resolver falls through to config.
+        $this->assertSame(1234, $resolver->resolve(new PropertyMissingTtlFixture()));
+    }
+
+    public function testResolveFallsBackWhenTypedPropertyIsUninitialized(): void
+    {
+        Config::set('lada-cache.model_ttls', [PropertyUninitializedTtlFixture::class => 4321]);
+        $resolver = new TtlResolver();
+
+        // `public ?int $ladaTtl;` (typed, no default) — property_exists() is true
+        // but reading it would throw Error("must not be accessed before initialization").
+        // The trait guards with ReflectionProperty::isInitialized() and returns null,
+        // letting config fallback take over.
+        $this->assertSame(4321, $resolver->resolve(new PropertyUninitializedTtlFixture()));
     }
 
     // ------------------------------------------------------------------
@@ -141,4 +187,35 @@ class HasTtlZeroFixture extends Model implements HasLadaTtl
     {
         return 0;
     }
+}
+
+class PropertyOnlyTtlFixture extends Model implements HasLadaTtl
+{
+    use LadaCacheTrait;
+
+    public ?int $ladaTtl = 120;
+}
+
+class PropertyNullTtlFixture extends Model implements HasLadaTtl
+{
+    use LadaCacheTrait;
+
+    // Explicit null → property_exists() true, value null → resolver falls back to config.
+    public ?int $ladaTtl = null;
+}
+
+class PropertyMissingTtlFixture extends Model implements HasLadaTtl
+{
+    use LadaCacheTrait;
+    // No $ladaTtl declared at all — covers the property_exists() === false branch.
+}
+
+class PropertyUninitializedTtlFixture extends Model implements HasLadaTtl
+{
+    use LadaCacheTrait;
+
+    // Typed property without a default: property_exists() true, but reading
+    // it before assignment throws an uninitialized Error. The trait's
+    // ReflectionProperty::isInitialized() guard prevents the crash.
+    public ?int $ladaTtl;
 }

--- a/tests/Integration/Cache/PerModelTtlTest.php
+++ b/tests/Integration/Cache/PerModelTtlTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Integration\Cache;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+use Spiritix\LadaCache\Contracts\HasLadaTtl;
+use Spiritix\LadaCache\Redis as LadaRedis;
+use Spiritix\LadaCache\Tests\TestCase;
+use Spiritix\LadaCache\TtlResolver;
+
+class PerModelTtlTest extends TestCase
+{
+    // ------------------------------------------------------------------
+    // TtlResolver: fallback chain
+    // ------------------------------------------------------------------
+
+    public function testResolveReturnsNullForNullModel(): void
+    {
+        $resolver = new TtlResolver();
+
+        $this->assertNull($resolver->resolve(null));
+    }
+
+    public function testResolveReturnsNullWhenNoOverridePresent(): void
+    {
+        Config::set('lada-cache.model_ttls', []);
+        $resolver = new TtlResolver();
+
+        $this->assertNull($resolver->resolve(new PlainFixture()));
+    }
+
+    public function testResolveUsesConfigModelTtlsWhenNoInterface(): void
+    {
+        Config::set('lada-cache.model_ttls', [PlainFixture::class => 7200]);
+        $resolver = new TtlResolver();
+
+        $this->assertSame(7200, $resolver->resolve(new PlainFixture()));
+    }
+
+    public function testResolvePrefersInterfaceOverConfig(): void
+    {
+        // Fixture returns 60; config says 9999 — interface wins
+        Config::set('lada-cache.model_ttls', [HasTtlFixture::class => 9999]);
+        $resolver = new TtlResolver();
+
+        $this->assertSame(60, $resolver->resolve(new HasTtlFixture()));
+    }
+
+    public function testResolveFallsBackToConfigWhenInterfaceReturnsNull(): void
+    {
+        Config::set('lada-cache.model_ttls', [HasTtlNullFixture::class => 1800]);
+        $resolver = new TtlResolver();
+
+        $this->assertSame(1800, $resolver->resolve(new HasTtlNullFixture()));
+    }
+
+    public function testResolveReturnsZeroWhenInterfaceExplicitlyReturnsZero(): void
+    {
+        // 0 = "persist forever" — distinct from null = defer to fallback
+        $resolver = new TtlResolver();
+
+        $this->assertSame(0, $resolver->resolve(new HasTtlZeroFixture()));
+    }
+
+    // ------------------------------------------------------------------
+    // Cache::set: TTL semantics with per-model values
+    // ------------------------------------------------------------------
+
+    public function testCacheSetUsesExplicitTtlWhenProvided(): void
+    {
+        $cache = app('lada.cache');
+        $redis = new LadaRedis();
+
+        $cache->set('explicit-ttl-key', ['t:tag'], ['data' => 1], 120);
+
+        $ttl = (int) $redis->ttl($redis->prefix('explicit-ttl-key'));
+
+        // Allow ±5s drift; should be ~120
+        $this->assertGreaterThan(115, $ttl);
+        $this->assertLessThanOrEqual(120, $ttl);
+    }
+
+    public function testCacheSetZeroTtlPersistsForever(): void
+    {
+        $cache = app('lada.cache');
+        $redis = new LadaRedis();
+
+        $cache->set('zero-ttl-key', ['t:tag'], ['data' => 1], 0);
+
+        // Redis TTL = -1 means key exists with no expiration
+        $this->assertSame(-1, (int) $redis->ttl($redis->prefix('zero-ttl-key')));
+    }
+
+    public function testCacheSetNullTtlFallsBackToGlobal(): void
+    {
+        Config::set('lada-cache.expiration_time', 300);
+        // Re-resolve because Cache reads expiration_time at construction
+        app()->forgetInstance('lada.cache');
+
+        $cache = app('lada.cache');
+        $redis = new LadaRedis();
+
+        $cache->set('null-ttl-key', ['t:tag'], ['data' => 1], null);
+
+        $ttl = (int) $redis->ttl($redis->prefix('null-ttl-key'));
+        $this->assertGreaterThan(295, $ttl);
+        $this->assertLessThanOrEqual(300, $ttl);
+    }
+}
+
+// ------------------------------------------------------------------
+// Minimal fixtures — Eloquent models implementing HasLadaTtl
+// ------------------------------------------------------------------
+
+class PlainFixture extends Model
+{
+}
+
+class HasTtlFixture extends Model implements HasLadaTtl
+{
+    public function getLadaTtl(): ?int
+    {
+        return 60;
+    }
+}
+
+class HasTtlNullFixture extends Model implements HasLadaTtl
+{
+    public function getLadaTtl(): ?int
+    {
+        return null;
+    }
+}
+
+class HasTtlZeroFixture extends Model implements HasLadaTtl
+{
+    public function getLadaTtl(): ?int
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
## Summary

Adds per-model cache TTL overrides without breaking the global `expiration_time` default. Models opt in via the new `HasLadaTtl` interface, and `LadaCacheTrait` provides a default `getLadaTtl()` implementation so the common case is a single property declaration:

```php
// 1) Property — easiest, common case (recommended)
class City extends Model implements HasLadaTtl
{
    use LadaCacheTrait;
    public ?int $ladaTtl = 86400 * 30; // 30 days
}

// 2) Method override — when dynamic logic is required
class Tournament extends Model implements HasLadaTtl
{
    use LadaCacheTrait;
    public function getLadaTtl(): ?int
    {
        return $this->is_live ? 60 : 3600;
    }
}

// 3) Static config — for models you can't (or don't want to) modify
// config/lada-cache.php
'model_ttls' => [
    App\Models\Tournament::class => 300,   // 5 minutes for hot state
    App\Models\Order::class      => null,  // defer to global
],
```

## Resolution order

First non-null wins:

1. Model implements `HasLadaTtl` → `\$model->getLadaTtl()`
   - Default impl provided by `LadaCacheTrait` reads `public ?int \$ladaTtl`
   - Models can override the method instead for dynamic logic
2. `config('lada-cache.model_ttls.<FQCN>')`
3. `config('lada-cache.expiration_time')` global

## TTL value semantics

| Value | Meaning |
|---|---|
| `null`   | Defer to next layer in resolution chain |
| `> 0`    | TTL in seconds |
| `0`      | Persist forever (cache until tag invalidation) — same as existing `expiration_time = 0` behavior |
| `< 0`    | Same as 0 (forever) — discouraged, prefer 0 |

## Why the property is on the model, not on the trait

PHP does not allow a subclass to redeclare a trait-provided property with a different default value:

```
Fatal error: City and LadaCacheTrait define the same property
(\$ladaTtl) in the composition. However, the definition differs and
is considered incompatible.
```

So `LadaCacheTrait` cannot ship `public ?int \$ladaTtl = null;` itself. Instead the trait supplies only the **method** and lets each model declare the property with whatever default it needs. `property_exists()` inside the trait method handles models that implement `HasLadaTtl` without declaring the property.

## Defensive read for uninitialized typed properties

`public ?int \$ladaTtl;` (typed, no default) is legal PHP. `property_exists()` returns `true`, but reading the property before any assignment throws:

```
Error: Typed property City::\$ladaTtl must not be accessed before initialization
```

The trait method uses `ReflectionProperty::isInitialized()` to detect this state and returns `null`, letting the resolver fall through to the config-level fallback instead of crashing the request.

## Files

- `src/Contracts/HasLadaTtl.php` — new interface
- `src/Database/LadaCacheTrait.php` — default `getLadaTtl()` reading `\$ladaTtl` property with uninitialized guard
- `src/TtlResolver.php` — new Octane-safe resolver service (singleton, no mutable state)
- `src/Cache.php` — `set(..., ?int \$ttl = null)` now accepts per-call TTL. Backward compatible default.
- `src/QueryHandler.php` — resolves model TTL before each `cache->set()`
- `src/LadaCacheServiceProvider.php` — registers `lada.ttl_resolver` singleton
- `config/lada-cache.php` — new `model_ttls` config section with examples

## Tests

13 tests in `tests/Integration/Cache/PerModelTtlTest.php`:

**TtlResolver fallback chain (interface-based):**
- null model → null
- no override present → null
- config-only override → returns config value
- interface override → wins over config
- interface returns null → falls back to config
- interface returns 0 → explicitly persisted as 0 (not null)

**LadaCacheTrait property-based default `getLadaTtl()`:**
- property only, no method override → property value is used
- property defaults to null → falls back to config
- implements interface without declaring property → falls back to config
- typed property with no default value (uninitialized) → falls back to config

**Cache::set TTL semantics:**
- explicit TTL is honored (verified via Redis `TTL` command)
- ttl=0 → Redis `TTL` returns -1 (no expiration)
- ttl=null → falls back to global `expiration_time`

## Compatibility

- `Cache::set()` 4th parameter is optional with `?int \$ttl = null` default → no break for existing callers
- New `lada.ttl_resolver` singleton is additive; provider's `provides()` array updated
- Models without the interface and without a `model_ttls` entry behave exactly as before
- Models that override `getLadaTtl()` explicitly continue to take precedence over the trait's default impl
- Tested under PHPStan level 7