### PR TITLE
feat: add lada-cache:calibrate command for auto TTL calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,72 @@ and `->runInBackground()` — safe under multi-server Horizon deployments.
 - Pipelined `OBJECT IDLETIME` calls and cursor-driven `SSCAN`/`SCAN` keep
   the command non-blocking even against millions of cached keys.
 
+## Stats / Activity Counter
+
+Lada Cache can publish a `LadaCacheActivity` event on every cache hit, miss,
+and invalidate. The event is **opt-in** — disabled by default so unused
+installs incur zero overhead on the query hot path.
+
+```env
+LADA_CACHE_EVENTS_ENABLED=true
+```
+
+The event carries the action (`hit`/`miss`/`invalidate`), the cache key, the
+tags, and the primary table — letting you wire any listener you like (Prometheus
+exporter, structured log line, custom counter…).
+
+### Bundled StatsCounter listener
+
+For the common "count per-table activity over time" case, the package ships a
+buffered listener that writes hourly HASH buckets to Redis:
+
+```env
+LADA_CACHE_EVENTS_ENABLED=true
+LADA_CACHE_STATS_ENABLED=true
+```
+
+```
+lada:stats:YYYYMMDDHH
+  field "users:hit"        → 42819
+  field "users:miss"       → 512
+  field "users:invalidate" → 120
+  ...
+```
+
+Buckets self-evict via TTL (default 7 days). The counter aggregates in process
+memory and flushes when distinct (table:action) keys exceed
+`flush_max_batch`, when `flush_max_seconds` elapses since the last flush, or
+when the application terminates — works under FPM, Octane, queue workers, and
+the scheduler.
+
+### Activity-aware calibration
+
+When the StatsCounter is enabled, `lada-cache:calibrate` enriches its IDLETIME
+signal with read / write counts from the last `stats_lookback_hours` and labels
+each model with a signal source:
+
+| Signal | When | Effect |
+|--------|------|--------|
+| `idletime_only` | StatsReader unavailable or Redis lookup failed | Original IDLETIME-only TTL |
+| `no_activity` | reads + writes below `min_reads_for_signal` | Original IDLETIME-only TTL |
+| `write_heavy` | invalidates / (hits+misses) ≥ `write_heavy_ratio` | Skip survivor-bias floor (writes were going to invalidate anyway) |
+| `read_heavy` | otherwise | Hit-ratio proportional control toward `target_hit_ratio` |
+
+Tuning knobs (all `LADA_CACHE_CALIBRATION_*` env vars):
+
+```env
+LADA_CACHE_CALIBRATION_STATS_LOOKBACK_HOURS=168      # 7 days
+LADA_CACHE_CALIBRATION_MIN_READS_FOR_SIGNAL=10
+LADA_CACHE_CALIBRATION_WRITE_HEAVY_RATIO=0.5
+LADA_CACHE_CALIBRATION_TARGET_HIT_RATIO=0.80
+LADA_CACHE_CALIBRATION_HIT_RATIO_DEADBAND=0.05
+LADA_CACHE_CALIBRATION_HIT_RATIO_LEARNING_RATE=0.30
+LADA_CACHE_CALIBRATION_HIT_RATIO_MAX_STEP=0.20
+```
+
+The calibration log line includes per-signal counters so you can graph the
+distribution of read-heavy vs write-heavy models across runs.
+
 ## Known Issues and Limitations
 
 - Multiple connections (`DB::connection('foo')`) are only supported when using Lada’s connection integration. Models defining `$connection` work automatically.  

--- a/README.md
+++ b/README.md
@@ -153,7 +153,65 @@ php artisan lada-cache:disable
 
 # Re-enable cache
 php artisan lada-cache:enable
+
+# Auto-calibrate per-model TTLs from Redis OBJECT IDLETIME (see Auto-calibration below)
+php artisan lada-cache:calibrate              # dry-run
+php artisan lada-cache:calibrate --apply      # persist results
 ```
+
+## Auto-calibration
+
+Picking the right TTL per model is a guessing game without production data.
+`lada-cache:calibrate` removes the guesswork: it samples Redis `OBJECT IDLETIME`
+for cached keys belonging to each Lada-cached model, computes the P95 idle
+time, and derives a per-model TTL via:
+
+```
+calibrated_ttl = max(ceil(P95 * safety_factor), floor(previous_ttl / 2))
+```
+
+The floor term protects against survivor bias — `OBJECT IDLETIME` can only
+sample keys that haven't yet been evicted, so successive runs would otherwise
+shrink TTLs monotonically toward zero.
+
+Results are stored in the `lada_cache_calibrations` table (shipped via package
+migration) and consumed by `TtlResolver` between the `HasLadaTtl` interface
+and the static `model_ttls` config map.
+
+### Enable
+
+```env
+LADA_CACHE_CALIBRATION_ENABLED=true        # default: false
+LADA_CACHE_CALIBRATION_SAFETY_FACTOR=2.0   # P95 multiplier
+LADA_CACHE_CALIBRATION_MIN_SAMPLES=50      # skip models with fewer samples
+LADA_CACHE_CALIBRATION_CACHE_TTL=300       # in-memory map cache, seconds
+```
+
+Then publish & run the package migration:
+
+```bash
+php artisan vendor:publish --tag=migrations
+php artisan migrate
+```
+
+### Recommended cron
+
+Run weekly so each model's TTL converges on actual access patterns:
+
+```php
+// routes/console.php (Laravel 11+) or app/Console/Kernel.php
+Schedule::command('lada-cache:calibrate --apply')->weekly();
+```
+
+### Safety
+
+- Refuses to run when Redis `maxmemory-policy` is `*-lfu` (IDLETIME is
+  unsupported under LFU eviction — using it would calibrate every TTL
+  toward zero).
+- Dry-run by default; `--apply` is required to mutate `lada_cache_calibrations`.
+- Skips models with fewer than `min_samples` data points (including 0).
+- Pipelined `OBJECT IDLETIME` calls and cursor-driven `SSCAN`/`SCAN` keep
+  the command non-blocking even against millions of cached keys.
 
 ## Known Issues and Limitations
 

--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ php artisan lada-cache:calibrate --apply      # persist results
 
 Picking the right TTL per model is a guessing game without production data.
 `lada-cache:calibrate` removes the guesswork: it samples Redis `OBJECT IDLETIME`
-for cached keys belonging to each Lada-cached model, computes the P95 idle
-time, and derives a per-model TTL via:
+for cached keys belonging to each Lada-cached model, combines that with recent
+cache activity, and derives a per-model TTL via:
 
 ```
 calibrated_ttl = max(ceil(P95 * safety_factor), floor(previous_ttl / 2))
@@ -199,7 +199,7 @@ LADA_CACHE_CALIBRATION_ENABLED=true        # default: false
 LADA_CACHE_CALIBRATION_SAFETY_FACTOR=2.0   # P95 multiplier
 LADA_CACHE_CALIBRATION_MIN_SAMPLES=50      # skip models with fewer samples
 LADA_CACHE_CALIBRATION_CACHE_TTL=300       # in-memory map cache, seconds
-LADA_CACHE_CALIBRATION_SCHEDULE="0 3 * * 0"  # cron — empty string = no auto-schedule
+LADA_CACHE_CALIBRATION_SCHEDULE_INTERVAL=7 # run once every 7 days; 0 = no auto-schedule
 ```
 
 Then publish & run the package migration:
@@ -209,16 +209,16 @@ php artisan vendor:publish --tag=migrations
 php artisan migrate
 ```
 
-### Auto-scheduled cron
+### Auto-scheduled run
 
 The package auto-registers the calibration cron via
-`callAfterResolving(Schedule::class)` when both `enabled=true` and `schedule`
-(a cron expression) are set. The default schedule is **every Sunday at 03:00**
-(`0 3 * * 0`) — long enough for TTLs to converge on real access patterns
-without bombing Redis with daily scans.
+`callAfterResolving(Schedule::class)` when calibration is enabled and
+`schedule_interval` is greater than zero. The default is **once every 7 days**
+at 03:00 — long enough for TTLs to converge on real access patterns without
+bombing Redis with daily scans.
 
-To customise, override `LADA_CACHE_CALIBRATION_SCHEDULE` with any cron
-expression, or set it to an empty string and register the command yourself:
+To customise, set `LADA_CACHE_CALIBRATION_SCHEDULE_INTERVAL` to the number of
+days between runs, or set it to `0` and register the command yourself:
 
 ```php
 // routes/console.php (Laravel 11+) or app/Console/Kernel.php
@@ -238,53 +238,15 @@ and `->runInBackground()` — safe under multi-server Horizon deployments.
 - Pipelined `OBJECT IDLETIME` calls and cursor-driven `SSCAN`/`SCAN` keep
   the command non-blocking even against millions of cached keys.
 
-## Stats / Activity Counter
-
-Lada Cache can publish a `LadaCacheActivity` event on every cache hit, miss,
-and invalidate. The event is **opt-in** — disabled by default so unused
-installs incur zero overhead on the query hot path.
-
-```env
-LADA_CACHE_EVENTS_ENABLED=true
-```
-
-The event carries the action (`hit`/`miss`/`invalidate`), the cache key, the
-tags, and the primary table — letting you wire any listener you like (Prometheus
-exporter, structured log line, custom counter…).
-
-### Bundled StatsCounter listener
-
-For the common "count per-table activity over time" case, the package ships a
-buffered listener that writes hourly HASH buckets to Redis:
-
-```env
-LADA_CACHE_EVENTS_ENABLED=true
-LADA_CACHE_STATS_ENABLED=true
-```
-
-```
-lada:stats:YYYYMMDDHH
-  field "users:hit"        → 42819
-  field "users:miss"       → 512
-  field "users:invalidate" → 120
-  ...
-```
-
-Buckets self-evict via TTL (default 7 days). The counter aggregates in process
-memory and flushes when distinct (table:action) keys exceed
-`flush_max_batch`, when `flush_max_seconds` elapses since the last flush, or
-when the application terminates — works under FPM, Octane, queue workers, and
-the scheduler.
-
 ### Activity-aware calibration
 
-When the StatsCounter is enabled, `lada-cache:calibrate` enriches its IDLETIME
-signal with read / write counts from the last `stats_lookback_hours` and labels
-each model with a signal source:
+While calibration is enabled, Lada records lightweight per-table activity and
+uses it on the next `lada-cache:calibrate` run. Each model is labeled with a
+signal source:
 
 | Signal | When | Effect |
 |--------|------|--------|
-| `idletime_only` | StatsReader unavailable or Redis lookup failed | Original IDLETIME-only TTL |
+| `idletime_only` | Activity read unavailable or Redis lookup failed | Original IDLETIME-only TTL |
 | `no_activity` | reads + writes below `min_reads_for_signal` | Original IDLETIME-only TTL |
 | `write_heavy` | invalidates / (hits+misses) ≥ `write_heavy_ratio` | Skip survivor-bias floor (writes were going to invalidate anyway) |
 | `read_heavy` | otherwise | Hit-ratio proportional control toward `target_hit_ratio` |
@@ -292,13 +254,14 @@ each model with a signal source:
 Tuning knobs (all `LADA_CACHE_CALIBRATION_*` env vars):
 
 ```env
-LADA_CACHE_CALIBRATION_STATS_LOOKBACK_HOURS=168      # 7 days
+LADA_CACHE_CALIBRATION_ACTIVITY_LOOKBACK_HOURS=168      # 7 days
 LADA_CACHE_CALIBRATION_MIN_READS_FOR_SIGNAL=10
 LADA_CACHE_CALIBRATION_WRITE_HEAVY_RATIO=0.5
 LADA_CACHE_CALIBRATION_TARGET_HIT_RATIO=0.80
 LADA_CACHE_CALIBRATION_HIT_RATIO_DEADBAND=0.05
 LADA_CACHE_CALIBRATION_HIT_RATIO_LEARNING_RATE=0.30
 LADA_CACHE_CALIBRATION_HIT_RATIO_MAX_STEP=0.20
+LADA_CACHE_CALIBRATION_ACTIVITY_BUCKET_TTL_SECONDS=604800
 ```
 
 The calibration log line includes per-signal counters so you can graph the

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ LADA_CACHE_CALIBRATION_ENABLED=true        # default: false
 LADA_CACHE_CALIBRATION_SAFETY_FACTOR=2.0   # P95 multiplier
 LADA_CACHE_CALIBRATION_MIN_SAMPLES=50      # skip models with fewer samples
 LADA_CACHE_CALIBRATION_CACHE_TTL=300       # in-memory map cache, seconds
+LADA_CACHE_CALIBRATION_SCHEDULE="0 3 * * 0"  # cron — empty string = no auto-schedule
 ```
 
 Then publish & run the package migration:
@@ -194,14 +195,24 @@ php artisan vendor:publish --tag=migrations
 php artisan migrate
 ```
 
-### Recommended cron
+### Auto-scheduled cron
 
-Run weekly so each model's TTL converges on actual access patterns:
+The package auto-registers the calibration cron via
+`callAfterResolving(Schedule::class)` when both `enabled=true` and `schedule`
+(a cron expression) are set. The default schedule is **every Sunday at 03:00**
+(`0 3 * * 0`) — long enough for TTLs to converge on real access patterns
+without bombing Redis with daily scans.
+
+To customise, override `LADA_CACHE_CALIBRATION_SCHEDULE` with any cron
+expression, or set it to an empty string and register the command yourself:
 
 ```php
 // routes/console.php (Laravel 11+) or app/Console/Kernel.php
 Schedule::command('lada-cache:calibrate --apply')->weekly();
 ```
+
+The auto-registered job runs with `->onOneServer()`, `->withoutOverlapping()`,
+and `->runInBackground()` — safe under multi-server Horizon deployments.
 
 ### Safety
 

--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -74,8 +74,10 @@ return [
     | global expiration_time. Resolution order (first non-null wins):
     |   1. $model->getLadaTtl() if model implements
     |      Spiritix\LadaCache\Contracts\HasLadaTtl
-    |   2. config('lada-cache.model_ttls.<FQCN>')
-    |   3. config('lada-cache.expiration_time') (global)
+    |   2. lada_cache_calibrations.calibrated_ttl
+    |      (auto-calibration via lada-cache:calibrate, see "Calibration" below)
+    |   3. config('lada-cache.model_ttls.<FQCN>')
+    |   4. config('lada-cache.expiration_time') (global)
     |
     | Examples:
     |   App\Models\City::class       => 86400 * 30, // 30 days for rarely-changing data
@@ -87,6 +89,41 @@ return [
     */
     'model_ttls' => [
         // App\Models\City::class => 86400 * 30,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-calibration
+    |--------------------------------------------------------------------------
+    |
+    | The `lada-cache:calibrate` Artisan command samples Redis OBJECT IDLETIME
+    | for cached keys belonging to each Lada-cached model, computes the
+    | P95 idle time, and derives a per-model TTL via
+    |
+    |     calibrated_ttl = max(ceil(P95 * safety_factor), floor(previous_ttl / 2))
+    |
+    | The floor term guards against survivor bias — OBJECT IDLETIME can only
+    | sample keys that haven't yet been evicted, so successive runs would
+    | otherwise shrink TTLs monotonically toward zero.
+    |
+    | Results are stored in the `lada_cache_calibrations` table and consumed
+    | by TtlResolver between the HasLadaTtl interface and the static
+    | `model_ttls` map (see "Per-model TTL overrides" above).
+    |
+    | Safety:
+    |   - The command refuses to run when Redis maxmemory-policy is *-lfu
+    |     (IDLETIME is unsupported under LFU eviction).
+    |   - `--apply` is required to persist; the default is a dry-run table.
+    |   - Models with fewer than `min_samples` data points are skipped.
+    |
+    | Designed for periodic cron use, e.g. weekly: `lada-cache:calibrate --apply`.
+    |
+    */
+    'calibration' => [
+        'enabled' => (bool) env('LADA_CACHE_CALIBRATION_ENABLED', false),
+        'safety_factor' => (float) env('LADA_CACHE_CALIBRATION_SAFETY_FACTOR', 2.0),
+        'min_samples' => (int) env('LADA_CACHE_CALIBRATION_MIN_SAMPLES', 50),
+        'cache_ttl' => (int) env('LADA_CACHE_CALIBRATION_CACHE_TTL', 300),
     ],
 
     /*

--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -67,38 +67,12 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Per-model TTL overrides
-    |--------------------------------------------------------------------------
-    |
-    | Map of model FQCN to TTL in seconds. Models listed here override the
-    | global expiration_time. Resolution order (first non-null wins):
-    |   1. $model->getLadaTtl() if model implements
-    |      Spiritix\LadaCache\Contracts\HasLadaTtl
-    |   2. lada_cache_calibrations.calibrated_ttl
-    |      (auto-calibration via lada-cache:calibrate, see "Calibration" below)
-    |   3. config('lada-cache.model_ttls.<FQCN>')
-    |   4. config('lada-cache.expiration_time') (global)
-    |
-    | Examples:
-    |   App\Models\City::class       => 86400 * 30, // 30 days for rarely-changing data
-    |   App\Models\Tournament::class => 300,        // 5 minutes for hot state
-    |   App\Models\Order::class      => null,       // fall through to global
-    |
-    | 0 = persist forever (cache until tag-based invalidation).
-    |
-    */
-    'model_ttls' => [
-        // App\Models\City::class => 86400 * 30,
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
     | Auto-calibration
     |--------------------------------------------------------------------------
     |
     | The `lada-cache:calibrate` Artisan command samples Redis OBJECT IDLETIME
-    | for cached keys belonging to each Lada-cached model, computes the
-    | P95 idle time, and derives a per-model TTL via
+    | for cached keys belonging to each Lada-cached model, combines that signal
+    | with recent cache activity, and derives a per-model TTL via
     |
     |     calibrated_ttl = max(ceil(P95 * safety_factor), floor(previous_ttl / 2))
     |
@@ -116,7 +90,7 @@ return [
     |   - `--apply` is required to persist; the default is a dry-run table.
     |   - Models with fewer than `min_samples` data points are skipped.
     |
-    | Designed for periodic cron use, e.g. weekly: `lada-cache:calibrate --apply`.
+    | Designed for periodic use, e.g. weekly: `lada-cache:calibrate --apply`.
     |
     */
     'calibration' => [
@@ -129,31 +103,25 @@ return [
         // With ~500 cached models a batch of 100 reduces DB round-trips ~5x.
         'batch_size' => (int) env('LADA_CACHE_CALIBRATION_BATCH_SIZE', 100),
 
-        // Cron expression for the auto-scheduled calibration run. Empty string disables
-        // the auto-schedule (you can still invoke `php artisan lada-cache:calibrate --apply`
-        // manually or register it yourself in `routes/console.php`).
-        //
-        // Default `0 3 * * 0` = every Sunday at 03:00. Both `enabled=true` AND a non-empty
-        // schedule string are required for the service provider to register the cron.
-        'schedule' => (string) env('LADA_CACHE_CALIBRATION_SCHEDULE', '0 3 * * 0'),
+        // Number of days between auto-scheduled calibration runs.
+        // Default 7 = once a week. Set 0 to disable the auto-schedule (you can
+        // still invoke `php artisan lada-cache:calibrate --apply` manually or
+        // register it yourself in `routes/console.php`).
+        'schedule_interval' => (int) env('LADA_CACHE_CALIBRATION_SCHEDULE_INTERVAL', 7),
 
-        // -------------------------------------------------------------------
-        // Activity-aware calibration (opt-in — requires `events.enabled` AND
-        // `stats.enabled` so StatsCounter has data to read).
-        // -------------------------------------------------------------------
-        //
+        // Recent activity is recorded automatically while calibration is enabled.
         // The calibrate command can enrich the IDLETIME signal with per-table
-        // read / write counts recorded by StatsCounter. With activity data:
+        // read / write counts. With activity data:
         //   - `write_heavy` tables skip the survivor-bias floor so an invalidation
         //     -dominated workload doesn't inflate TTL into wasted memory.
         //   - `read_heavy` tables run through a convergent hit_ratio controller
         //     that pulls TTL toward `target_hit_ratio` by bounded steps.
-        // Without activity (Redis down, stats disabled, cold window) the command
+        // Without activity (Redis down or cold window) the command
         // falls back to the original IDLETIME-only behavior.
 
-        // How far back to aggregate StatsCounter buckets, in hours.
-        // Default 168 = 7 days, matching the bucket retention default below.
-        'stats_lookback_hours' => (int) env('LADA_CACHE_CALIBRATION_STATS_LOOKBACK_HOURS', 168),
+        // How far back to aggregate activity buckets, in hours.
+        // Default 168 = 7 days, matching the retention default below.
+        'activity_lookback_hours' => (int) env('LADA_CACHE_CALIBRATION_ACTIVITY_LOOKBACK_HOURS', 168),
 
         // Minimum reads+writes in the lookback window before the signal is
         // trusted. Below this, the activity adjustment is skipped and the run
@@ -171,62 +139,39 @@ return [
         'hit_ratio_deadband' => (float) env('LADA_CACHE_CALIBRATION_HIT_RATIO_DEADBAND', 0.05),
         'hit_ratio_learning_rate' => (float) env('LADA_CACHE_CALIBRATION_HIT_RATIO_LEARNING_RATE', 0.30),
         'hit_ratio_max_step' => (float) env('LADA_CACHE_CALIBRATION_HIT_RATIO_MAX_STEP', 0.20),
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Events
-    |--------------------------------------------------------------------------
-    |
-    | Lada Cache dispatches a {@see Spiritix\LadaCache\Events\LadaCacheActivity}
-    | event on every cache hit / miss / invalidate when enabled. This is an
-    | opt-in monitoring hook — disabled by default so unused installs incur
-    | zero overhead on the query hot path.
-    |
-    | Activation requires `events.enabled = true`. Listeners can read the
-    | (action, key, tags, table) payload to build their own counters, or use
-    | the bundled {@see Spiritix\LadaCache\Stats\StatsCounter} listener
-    | configured below.
-    |
-    */
-    'events' => [
-        'enabled' => (bool) env('LADA_CACHE_EVENTS_ENABLED', false),
-    ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Stats Counter
-    |--------------------------------------------------------------------------
-    |
-    | When `stats.enabled = true` (and `events.enabled = true`), the bundled
-    | StatsCounter listener aggregates LadaCacheActivity events in process
-    | memory and periodically writes per-table HASH counters to Redis:
-    |
-    |   lada:stats:YYYYMMDDHH
-    |     field "users:hit"        → 42819
-    |     field "users:miss"       → 512
-    |     field "users:invalidate" → 120
-    |     ...
-    |
-    | Flush triggers (whichever fires first):
-    |   - Distinct (table:action) keys exceed `flush_max_batch`
-    |   - Time since last flush exceeds `flush_max_seconds`
-    |   - The application terminates
-    |
-    | The `lada-cache:calibrate` command reads these buckets via StatsReader
-    | to drive activity-aware TTL adjustment (see "Activity-aware calibration"
-    | above).
-    |
-    */
-    'stats' => [
-        'enabled' => (bool) env('LADA_CACHE_STATS_ENABLED', false),
 
         // In-memory aggregation limits before forcing a flush.
-        'flush_max_batch' => (int) env('LADA_CACHE_STATS_FLUSH_MAX_BATCH', 100),
-        'flush_max_seconds' => (float) env('LADA_CACHE_STATS_FLUSH_MAX_SECONDS', 5.0),
+        'activity_flush_max_batch' => (int) env('LADA_CACHE_CALIBRATION_ACTIVITY_FLUSH_MAX_BATCH', 100),
+        'activity_flush_max_seconds' => (float) env('LADA_CACHE_CALIBRATION_ACTIVITY_FLUSH_MAX_SECONDS', 5.0),
 
         // Per-bucket retention in seconds. Default = 7 days.
-        'bucket_ttl_seconds' => (int) env('LADA_CACHE_STATS_BUCKET_TTL_SECONDS', 86400 * 7),
+        'activity_bucket_ttl_seconds' => (int) env('LADA_CACHE_CALIBRATION_ACTIVITY_BUCKET_TTL_SECONDS', 86400 * 7),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Per-model TTL overrides
+    |--------------------------------------------------------------------------
+    |
+    | Map of model FQCN to TTL in seconds. Models listed here override the
+    | global expiration_time. Resolution order (first non-null wins):
+    |   1. $model->getLadaTtl() if model implements
+    |      Spiritix\LadaCache\Contracts\HasLadaTtl
+    |   2. lada_cache_calibrations.calibrated_ttl
+    |      (auto-calibration via lada-cache:calibrate, see "Auto-calibration" above)
+    |   3. config('lada-cache.model_ttls.<FQCN>')
+    |   4. config('lada-cache.expiration_time') (global)
+    |
+    | Examples:
+    |   App\Models\City::class       => 86400 * 30, // 30 days for rarely-changing data
+    |   App\Models\Tournament::class => 300,        // 5 minutes for hot state
+    |   App\Models\Order::class      => null,       // fall through to global
+    |
+    | 0 = persist forever (cache until tag-based invalidation).
+    |
+    */
+    'model_ttls' => [
+        // App\Models\City::class => 86400 * 30,
     ],
 
     /*

--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -67,6 +67,30 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Per-model TTL overrides
+    |--------------------------------------------------------------------------
+    |
+    | Map of model FQCN to TTL in seconds. Models listed here override the
+    | global expiration_time. Resolution order (first non-null wins):
+    |   1. $model->getLadaTtl() if model implements
+    |      Spiritix\LadaCache\Contracts\HasLadaTtl
+    |   2. config('lada-cache.model_ttls.<FQCN>')
+    |   3. config('lada-cache.expiration_time') (global)
+    |
+    | Examples:
+    |   App\Models\City::class       => 86400 * 30, // 30 days for rarely-changing data
+    |   App\Models\Tournament::class => 300,        // 5 minutes for hot state
+    |   App\Models\Order::class      => null,       // fall through to global
+    |
+    | 0 = persist forever (cache until tag-based invalidation).
+    |
+    */
+    'model_ttls' => [
+        // App\Models\City::class => 86400 * 30,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Cache Granularity
     |--------------------------------------------------------------------------
     |

--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -132,6 +132,97 @@ return [
         // Default `0 3 * * 0` = every Sunday at 03:00. Both `enabled=true` AND a non-empty
         // schedule string are required for the service provider to register the cron.
         'schedule' => (string) env('LADA_CACHE_CALIBRATION_SCHEDULE', '0 3 * * 0'),
+
+        // -------------------------------------------------------------------
+        // Activity-aware calibration (opt-in — requires `events.enabled` AND
+        // `stats.enabled` so StatsCounter has data to read).
+        // -------------------------------------------------------------------
+        //
+        // The calibrate command can enrich the IDLETIME signal with per-table
+        // read / write counts recorded by StatsCounter. With activity data:
+        //   - `write_heavy` tables skip the survivor-bias floor so an invalidation
+        //     -dominated workload doesn't inflate TTL into wasted memory.
+        //   - `read_heavy` tables run through a convergent hit_ratio controller
+        //     that pulls TTL toward `target_hit_ratio` by bounded steps.
+        // Without activity (Redis down, stats disabled, cold window) the command
+        // falls back to the original IDLETIME-only behavior.
+
+        // How far back to aggregate StatsCounter buckets, in hours.
+        // Default 168 = 7 days, matching the bucket retention default below.
+        'stats_lookback_hours' => (int) env('LADA_CACHE_CALIBRATION_STATS_LOOKBACK_HOURS', 168),
+
+        // Minimum reads+writes in the lookback window before the signal is
+        // trusted. Below this, the activity adjustment is skipped and the run
+        // is labeled 'no_activity'. Guards against fitting TTL to thin data.
+        'min_reads_for_signal' => (int) env('LADA_CACHE_CALIBRATION_MIN_READS_FOR_SIGNAL', 10),
+
+        // invalidates / (hits+misses) ≥ this ratio classifies the table as
+        // write_heavy. Default 0.5 = invalidations equal reads.
+        'write_heavy_ratio' => (float) env('LADA_CACHE_CALIBRATION_WRITE_HEAVY_RATIO', 0.5),
+
+        // Read-heavy proportional control parameters (HitRatioAdjustment).
+        // Defaults: pull toward 80% hit ratio, ±20% per-run step,
+        // 30% learning rate, 5% deadband for hysteresis.
+        'target_hit_ratio' => (float) env('LADA_CACHE_CALIBRATION_TARGET_HIT_RATIO', 0.80),
+        'hit_ratio_deadband' => (float) env('LADA_CACHE_CALIBRATION_HIT_RATIO_DEADBAND', 0.05),
+        'hit_ratio_learning_rate' => (float) env('LADA_CACHE_CALIBRATION_HIT_RATIO_LEARNING_RATE', 0.30),
+        'hit_ratio_max_step' => (float) env('LADA_CACHE_CALIBRATION_HIT_RATIO_MAX_STEP', 0.20),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Events
+    |--------------------------------------------------------------------------
+    |
+    | Lada Cache dispatches a {@see Spiritix\LadaCache\Events\LadaCacheActivity}
+    | event on every cache hit / miss / invalidate when enabled. This is an
+    | opt-in monitoring hook — disabled by default so unused installs incur
+    | zero overhead on the query hot path.
+    |
+    | Activation requires `events.enabled = true`. Listeners can read the
+    | (action, key, tags, table) payload to build their own counters, or use
+    | the bundled {@see Spiritix\LadaCache\Stats\StatsCounter} listener
+    | configured below.
+    |
+    */
+    'events' => [
+        'enabled' => (bool) env('LADA_CACHE_EVENTS_ENABLED', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stats Counter
+    |--------------------------------------------------------------------------
+    |
+    | When `stats.enabled = true` (and `events.enabled = true`), the bundled
+    | StatsCounter listener aggregates LadaCacheActivity events in process
+    | memory and periodically writes per-table HASH counters to Redis:
+    |
+    |   lada:stats:YYYYMMDDHH
+    |     field "users:hit"        → 42819
+    |     field "users:miss"       → 512
+    |     field "users:invalidate" → 120
+    |     ...
+    |
+    | Flush triggers (whichever fires first):
+    |   - Distinct (table:action) keys exceed `flush_max_batch`
+    |   - Time since last flush exceeds `flush_max_seconds`
+    |   - The application terminates
+    |
+    | The `lada-cache:calibrate` command reads these buckets via StatsReader
+    | to drive activity-aware TTL adjustment (see "Activity-aware calibration"
+    | above).
+    |
+    */
+    'stats' => [
+        'enabled' => (bool) env('LADA_CACHE_STATS_ENABLED', false),
+
+        // In-memory aggregation limits before forcing a flush.
+        'flush_max_batch' => (int) env('LADA_CACHE_STATS_FLUSH_MAX_BATCH', 100),
+        'flush_max_seconds' => (float) env('LADA_CACHE_STATS_FLUSH_MAX_SECONDS', 5.0),
+
+        // Per-bucket retention in seconds. Default = 7 days.
+        'bucket_ttl_seconds' => (int) env('LADA_CACHE_STATS_BUCKET_TTL_SECONDS', 86400 * 7),
     ],
 
     /*

--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -124,6 +124,14 @@ return [
         'safety_factor' => (float) env('LADA_CACHE_CALIBRATION_SAFETY_FACTOR', 2.0),
         'min_samples' => (int) env('LADA_CACHE_CALIBRATION_MIN_SAMPLES', 50),
         'cache_ttl' => (int) env('LADA_CACHE_CALIBRATION_CACHE_TTL', 300),
+
+        // Cron expression for the auto-scheduled calibration run. Empty string disables
+        // the auto-schedule (you can still invoke `php artisan lada-cache:calibrate --apply`
+        // manually or register it yourself in `routes/console.php`).
+        //
+        // Default `0 3 * * 0` = every Sunday at 03:00. Both `enabled=true` AND a non-empty
+        // schedule string are required for the service provider to register the cron.
+        'schedule' => (string) env('LADA_CACHE_CALIBRATION_SCHEDULE', '0 3 * * 0'),
     ],
 
     /*

--- a/config/lada-cache.php
+++ b/config/lada-cache.php
@@ -125,6 +125,10 @@ return [
         'min_samples' => (int) env('LADA_CACHE_CALIBRATION_MIN_SAMPLES', 50),
         'cache_ttl' => (int) env('LADA_CACHE_CALIBRATION_CACHE_TTL', 300),
 
+        // How many --apply rows to buffer before issuing a single bulk UPSERT.
+        // With ~500 cached models a batch of 100 reduces DB round-trips ~5x.
+        'batch_size' => (int) env('LADA_CACHE_CALIBRATION_BATCH_SIZE', 100),
+
         // Cron expression for the auto-scheduled calibration run. Empty string disables
         // the auto-schedule (you can still invoke `php artisan lada-cache:calibrate --apply`
         // manually or register it yourself in `routes/console.php`).

--- a/database/migrations/2024_01_01_000001_create_lada_cache_calibrations_table.php
+++ b/database/migrations/2024_01_01_000001_create_lada_cache_calibrations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('lada_cache_calibrations', function (Blueprint $table): void {
+            $table->id();
+            $table->string('model_class')->unique();
+            $table->string('table_name')->index();
+            $table->unsignedInteger('calibrated_ttl');
+            $table->json('metrics');
+            $table->timestamp('calibrated_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lada_cache_calibrations');
+    }
+};

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiritix\LadaCache;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
@@ -28,8 +29,7 @@ final class Cache
         private readonly Encoder $encoder,
         ?int $expirationTime = null,
     ) {
-        $configTtl = config('lada-cache.expiration_time', 0);
-        $this->expirationTime = $expirationTime ?? (is_numeric($configTtl) ? (int) $configTtl : 0);
+        $this->expirationTime = $expirationTime ?? Config::integer('lada-cache.expiration_time', 0);
     }
 
     public function has(string $key): bool
@@ -90,6 +90,8 @@ final class Cache
     public function flush(): void
     {
         try {
+            // `database.redis.options.prefix` may be `false` (legacy "no prefix") in addition to
+            // null / empty string / string — `Config::string()` is too strict here.
             $rawPrefix = config('database.redis.options.prefix');
             $connectionPrefix = is_string($rawPrefix) ? $rawPrefix : '';
 

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -28,7 +28,8 @@ final class Cache
         private readonly Encoder $encoder,
         ?int $expirationTime = null,
     ) {
-        $this->expirationTime = $expirationTime ?? (int) config('lada-cache.expiration_time', 0);
+        $configTtl = config('lada-cache.expiration_time', 0);
+        $this->expirationTime = $expirationTime ?? (is_numeric($configTtl) ? (int) $configTtl : 0);
     }
 
     public function has(string $key): bool
@@ -44,7 +45,7 @@ final class Cache
      *   - $ttl = 0  : SET key value (no expiration — persist forever, rely on tag invalidation)
      *   - $ttl null : fall back to the global expirationTime (which itself follows the same > 0 / = 0 rule)
      *
-     * @param array<string> $tags
+     * @param  array<string>  $tags
      */
     public function set(string $key, array $tags, mixed $data, ?int $ttl = null): void
     {
@@ -70,6 +71,9 @@ final class Cache
         return $encoded === null ? null : $this->encoder->decode($encoded);
     }
 
+    /**
+     * @param  array<string>  $tags
+     */
     public function repairTagMembership(string $key, array $tags): void
     {
         $prefixedKey = $this->redis->prefix($key);
@@ -86,7 +90,8 @@ final class Cache
     public function flush(): void
     {
         try {
-            $connectionPrefix = (string) (config('database.redis.options.prefix') ?? '');
+            $rawPrefix = config('database.redis.options.prefix');
+            $connectionPrefix = is_string($rawPrefix) ? $rawPrefix : '';
 
             // Fetch all Lada keys as returned by the connection (includes connection prefix if set)
             $keys = $this->redis->keys($this->redis->prefix('*'));
@@ -95,7 +100,7 @@ final class Cache
                 // Strip the connection-level prefix so the driver applies it exactly once when deleting
                 $toDelete = $connectionPrefix !== ''
                     ? array_map(
-                        static fn(string $k): string => str_starts_with($k, $connectionPrefix) ? substr($k, strlen($connectionPrefix)) : $k,
+                        static fn (string $k): string => str_starts_with($k, $connectionPrefix) ? substr($k, strlen($connectionPrefix)) : $k,
                         $keys
                     )
                     : $keys;

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -36,13 +36,24 @@ final class Cache
         return (bool) $this->redis->exists($this->redis->prefix($key));
     }
 
-    public function set(string $key, array $tags, mixed $data): void
+    /**
+     * Persist a cached query result under the given key with optional per-call TTL.
+     *
+     * TTL resolution:
+     *   - $ttl > 0  : SET key value EX $ttl (expires after $ttl seconds)
+     *   - $ttl = 0  : SET key value (no expiration — persist forever, rely on tag invalidation)
+     *   - $ttl null : fall back to the global expirationTime (which itself follows the same > 0 / = 0 rule)
+     *
+     * @param array<string> $tags
+     */
+    public function set(string $key, array $tags, mixed $data, ?int $ttl = null): void
     {
         $key = $this->redis->prefix($key);
         $value = $this->encoder->encode($data);
+        $effectiveTtl = $ttl ?? $this->expirationTime;
 
-        if ($this->expirationTime > 0) {
-            $this->redis->set($key, $value, 'EX', $this->expirationTime);
+        if ($effectiveTtl > 0) {
+            $this->redis->set($key, $value, 'EX', $effectiveTtl);
         } else {
             $this->redis->set($key, $value);
         }

--- a/src/Calibration/HitRatioAdjustment.php
+++ b/src/Calibration/HitRatioAdjustment.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Calibration;
+
+/**
+ * Convergent proportional control: pulls the hit_ratio signal toward a target
+ * by bounded steps. Used on the read-heavy calibrate path.
+ *
+ * Algorithm:
+ *   deviation = target - hitRatio
+ *   if |deviation| < deadband: return raw                       // hysteresis
+ *   raw_adj = 1 + learning_rate × deviation
+ *   adj     = clamp(raw_adj, 1 - max_step, 1 + max_step)        // bounded step
+ *   return max(1, ceil(raw × adj))
+ *
+ * Stability invariants:
+ *   - Per-run TTL change adj ∈ [1 - max_step, 1 + max_step] → bounded growth
+ *     and bounded decay symmetrically.
+ *   - |deviation| < deadband → no-op (oscillation guard around target).
+ *   - hit_ratio is monotone in TTL (longer TTL → more hits, until invalidations
+ *     dominate), so fixed point: hit_ratio ≈ target ⇒ adj → 1, TTL steady.
+ *   - With the survivor-bias floor applied in the caller (previousTtl / 2),
+ *     the combined update map is a geometric bounded contraction → guaranteed
+ *     to converge.
+ *
+ * Safety bounds:
+ *   - `maxStep` is capped at MAX_STEP_CEILING (0.95). If `1 - max_step` were
+ *     allowed to reach 0 or below, an extreme `learning_rate × deviation` could
+ *     drive `adj ≤ 0`, and ceil(raw × adj) could be 0 or negative. The caller
+ *     `max($adjusted, $floor)` would still preserve floor=0 (newly tracked
+ *     model with no prior TTL) → TTL=0 → `Cache::set` drops the EX argument
+ *     → "persist forever" semantics → memory leak. Capping at 0.95 keeps the
+ *     lower clamp ≥ 0.05 (at least 5% of the raw value).
+ *   - The final `max(1, ceil(raw × adj))` is the last-resort floor; even a
+ *     misconfigured input can never produce a zero or negative TTL.
+ *
+ * Static + dependency-free → trivial to unit-test, zero runtime overhead.
+ */
+final class HitRatioAdjustment
+{
+    /**
+     * Upper bound for `maxStep`. Setting `maxStep = 1` would push the lower
+     * clamp `1 - max_step` to 0, allowing the multiplier to collapse the TTL
+     * to zero. 0.95 guarantees at least 5% of the raw value survives the
+     * most aggressive single-step contraction.
+     */
+    private const float MAX_STEP_CEILING = 0.95;
+
+    /**
+     * @param  float|null  $hitRatio  null → adjustment skipped (no signal)
+     */
+    public static function apply(
+        int $raw,
+        ?float $hitRatio,
+        float $target,
+        float $deadband,
+        float $learningRate,
+        float $maxStep,
+    ): int {
+        if ($hitRatio === null) {
+            return $raw;
+        }
+
+        $deadband = max(0.0, $deadband);
+        $learningRate = max(0.0, $learningRate);
+        $maxStep = max(0.0, min(self::MAX_STEP_CEILING, $maxStep));
+
+        $deviation = $target - $hitRatio;
+
+        if (abs($deviation) < $deadband) {
+            return $raw;
+        }
+
+        $adjustment = 1.0 + ($learningRate * $deviation);
+        $adjustment = max(1.0 - $maxStep, min(1.0 + $maxStep, $adjustment));
+
+        return max(1, (int) ceil($raw * $adjustment));
+    }
+}

--- a/src/Calibration/TtlCalibrationRepository.php
+++ b/src/Calibration/TtlCalibrationRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Spiritix\LadaCache\Calibration;
 
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -96,14 +97,20 @@ final class TtlCalibrationRepository
      */
     private function map(): array
     {
-        $ttl = (int) config('lada-cache.calibration.cache_ttl', 300);
+        $ttl = Config::integer('lada-cache.calibration.cache_ttl', 300);
 
-        return Cache::remember(self::CACHE_KEY, $ttl, function (): array {
-            return DB::table($this->tableName)
+        /** @var array<class-string, int> $cached */
+        $cached = Cache::remember(self::CACHE_KEY, $ttl, function (): array {
+            /** @var array<class-string, int> $rows */
+            $rows = DB::table($this->tableName)
                 ->select(['model_class', 'calibrated_ttl'])
                 ->pluck('calibrated_ttl', 'model_class')
-                ->map(static fn ($v): int => (int) $v)
+                ->map(static fn ($v): int => is_numeric($v) ? (int) $v : 0)
                 ->all();
+
+            return $rows;
         });
+
+        return $cached;
     }
 }

--- a/src/Calibration/TtlCalibrationRepository.php
+++ b/src/Calibration/TtlCalibrationRepository.php
@@ -37,22 +37,47 @@ final class TtlCalibrationRepository
     /**
      * Persist (upsert) a single calibration row and bust the cache.
      *
-     * @param array<string, mixed> $metrics
+     * @param  array<string, mixed>  $metrics
      */
     public function upsert(string $modelClass, string $tableName, int $calibratedTtl, array $metrics): void
     {
-        $now = now();
+        $this->upsertMany([[
+            'model_class' => $modelClass,
+            'table_name' => $tableName,
+            'calibrated_ttl' => $calibratedTtl,
+            'metrics' => $metrics,
+        ]]);
+    }
 
-        DB::table($this->tableName)->updateOrInsert(
-            ['model_class' => $modelClass],
-            [
-                'table_name' => $tableName,
-                'calibrated_ttl' => $calibratedTtl,
-                'metrics' => json_encode($metrics, JSON_THROW_ON_ERROR),
-                'calibrated_at' => $now,
-                'updated_at' => $now,
-                'created_at' => $now,
-            ],
+    /**
+     * Persist multiple calibrations in a single SQL statement and bust the cache once.
+     *
+     * Each row: `['model_class' => string, 'table_name' => string, 'calibrated_ttl' => int, 'metrics' => array]`.
+     * Empty input is a no-op (no DB round-trip, no cache bust).
+     *
+     * @param  list<array{model_class: string, table_name: string, calibrated_ttl: int, metrics: array<string, mixed>}>  $rows
+     */
+    public function upsertMany(array $rows): void
+    {
+        if ($rows === []) {
+            return;
+        }
+
+        $now = now();
+        $values = array_map(static fn (array $row): array => [
+            'model_class' => $row['model_class'],
+            'table_name' => $row['table_name'],
+            'calibrated_ttl' => $row['calibrated_ttl'],
+            'metrics' => json_encode($row['metrics'], JSON_THROW_ON_ERROR),
+            'calibrated_at' => $now,
+            'updated_at' => $now,
+            'created_at' => $now,
+        ], $rows);
+
+        DB::table($this->tableName)->upsert(
+            $values,
+            ['model_class'],
+            ['table_name', 'calibrated_ttl', 'metrics', 'calibrated_at', 'updated_at'],
         );
 
         $this->bust();
@@ -78,8 +103,7 @@ final class TtlCalibrationRepository
                 ->select(['model_class', 'calibrated_ttl'])
                 ->pluck('calibrated_ttl', 'model_class')
                 ->map(static fn ($v): int => (int) $v)
-                ->all()
-            ;
+                ->all();
         });
     }
 }

--- a/src/Calibration/TtlCalibrationRepository.php
+++ b/src/Calibration/TtlCalibrationRepository.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Calibration;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Repository for per-model calibrated TTL values stored in `lada_cache_calibrations`.
+ *
+ * Hot path optimization: the full calibration map is cached in memory for
+ * `config('lada-cache.calibration.cache_ttl')` seconds — every cacheQuery would
+ * otherwise hit DB. Invalidation is explicit (`bust()`) after `lada-cache:calibrate --apply`.
+ *
+ * Octane-safe: no mutable instance state beyond constructor-injected dependencies.
+ */
+final class TtlCalibrationRepository
+{
+    public const string CACHE_KEY = 'lada-cache:calibrations';
+
+    public function __construct(
+        private readonly string $tableName = 'lada_cache_calibrations',
+    ) {}
+
+    /**
+     * Resolve the calibrated TTL for a model class, or null when none exists.
+     */
+    public function findForModel(string $modelClass): ?int
+    {
+        $map = $this->map();
+
+        return $map[$modelClass] ?? null;
+    }
+
+    /**
+     * Persist (upsert) a single calibration row and bust the cache.
+     *
+     * @param array<string, mixed> $metrics
+     */
+    public function upsert(string $modelClass, string $tableName, int $calibratedTtl, array $metrics): void
+    {
+        $now = now();
+
+        DB::table($this->tableName)->updateOrInsert(
+            ['model_class' => $modelClass],
+            [
+                'table_name' => $tableName,
+                'calibrated_ttl' => $calibratedTtl,
+                'metrics' => json_encode($metrics, JSON_THROW_ON_ERROR),
+                'calibrated_at' => $now,
+                'updated_at' => $now,
+                'created_at' => $now,
+            ],
+        );
+
+        $this->bust();
+    }
+
+    /**
+     * Clear the in-memory map cache. Call after `--apply` writes new calibrations.
+     */
+    public function bust(): void
+    {
+        Cache::forget(self::CACHE_KEY);
+    }
+
+    /**
+     * @return array<class-string, int>
+     */
+    private function map(): array
+    {
+        $ttl = (int) config('lada-cache.calibration.cache_ttl', 300);
+
+        return Cache::remember(self::CACHE_KEY, $ttl, function (): array {
+            return DB::table($this->tableName)
+                ->select(['model_class', 'calibrated_ttl'])
+                ->pluck('calibrated_ttl', 'model_class')
+                ->map(static fn ($v): int => (int) $v)
+                ->all()
+            ;
+        });
+    }
+}

--- a/src/Console/CalibrateCommand.php
+++ b/src/Console/CalibrateCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use ReflectionClass;
+use RuntimeException;
 use Spiritix\LadaCache\Calibration\HitRatioAdjustment;
 use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
 use Spiritix\LadaCache\Database\LadaCacheTrait;
@@ -19,8 +20,8 @@ use Spiritix\LadaCache\Stats\StatsReader;
 use Throwable;
 
 /**
- * Sample Redis OBJECT IDLETIME (and optionally StatsCounter activity) for
- * Lada-cached models and derive per-model TTLs.
+ * Sample Redis OBJECT IDLETIME and recent cache activity for Lada-cached
+ * models and derive per-model TTLs.
  *
  * Algorithm:
  *   1. Discover Eloquent models using LadaCacheTrait (or use --model=FQCN).
@@ -30,8 +31,8 @@ use Throwable;
  *   4. Compute P50, P95, max of the distribution.
  *   5. raw_calibrated = ceil(P95 × safety_factor).
  *   6. Floor against survivor-bias: max(raw, previousTtl / 2).
- *   7. (Opt-in) Read StatsCounter activity for the table over the last
- *      `stats_lookback_hours` hours and adjust the TTL by signal:
+ *   7. Read recent activity for the table over the configured lookback window
+ *      and adjust the TTL by signal:
  *        - 'idletime_only' — StatsReader unavailable or lookback=0; original behavior.
  *        - 'no_activity'   — reads+writes below `min_reads_for_signal`; original behavior.
  *        - 'write_heavy'   — invalidates/(hits+misses) ≥ `write_heavy_ratio`;
@@ -56,7 +57,7 @@ final class CalibrateCommand extends Command
                             {--models-path= : Override scanned directory (default: app_path("Models"))}
                             {--models-namespace= : Override scanned namespace (default: "App\\\\Models\\\\")}';
 
-    protected $description = 'Sample Redis OBJECT IDLETIME (and optional activity counters) for Lada-cached models and compute per-model TTLs.';
+    protected $description = 'Sample Redis OBJECT IDLETIME and recent activity for Lada-cached models and compute per-model TTLs.';
 
     public function __construct(
         private readonly ?Redis $redis = null,
@@ -74,10 +75,8 @@ final class CalibrateCommand extends Command
             return self::SUCCESS;
         }
 
-        // Calibration kapalıyken erken çık — ServiceProvider deps bind etmemiş olabilir
-        // (zero-arg singleton path). Önce flag, sonra deps null kontrolü; yoksa
-        // calibration.enabled=false default değerinde manuel
-        // `php artisan lada-cache:calibrate` çağrısı FAILURE ile düşer.
+        // Check the flag before dependency guards so the zero-argument command
+        // registered while calibration is disabled can exit cleanly.
         if (! (bool) config('lada-cache.calibration.enabled', false)) {
             $this->warn('Lada Cache calibration is disabled. Set LADA_CACHE_CALIBRATION_ENABLED=true to enable.');
 
@@ -115,9 +114,9 @@ final class CalibrateCommand extends Command
         $minSamples = Config::integer('lada-cache.calibration.min_samples', 50);
         $apply = (bool) $this->option('apply');
 
-        $lookbackHours = Config::integer('lada-cache.calibration.stats_lookback_hours', 168);
+        $lookbackHours = Config::integer('lada-cache.calibration.activity_lookback_hours', 168);
         $this->warnIfLookbackExceedsBucketTtl($lookbackHours);
-        // null  = stats signal unavailable (reader not configured OR Redis lookup failed);
+        // null  = activity signal unavailable (reader not configured OR Redis lookup failed);
         // []    = configured + reached Redis, but no activity recorded in window;
         // array = per-table activity counters.
         // We collapse the tri-state into an explicit `$statsState` enum-like
@@ -235,7 +234,7 @@ final class CalibrateCommand extends Command
                 ];
 
                 if (count($pending) >= $batchSize) {
-                    $this->repository->upsertMany($pending);
+                    $this->repository()->upsertMany($pending);
                     $pending = [];
                 }
 
@@ -260,7 +259,7 @@ final class CalibrateCommand extends Command
 
         // Residual rows that didn't fill the final batch.
         if ($pending !== []) {
-            $this->repository->upsertMany($pending);
+            $this->repository()->upsertMany($pending);
         }
 
         $this->table(
@@ -287,7 +286,7 @@ final class CalibrateCommand extends Command
     }
 
     /**
-     * Combine the IDLETIME-derived TTL with StatsCounter activity to pick a
+     * Combine the IDLETIME-derived TTL with recent activity to pick a
      * final value and label the signal source for downstream observability.
      *
      * `$statsState` is the explicit tri-state from {@see handle()}:
@@ -366,12 +365,12 @@ final class CalibrateCommand extends Command
 
     /**
      * Surface a self-contradicting config where the operator asked us to look
-     * back further than StatsCounter retains data. Older buckets have already
+     * back further than the activity bucket retention. Older buckets have already
      * expired, so the pipeline reads return empty for the trailing keys.
      * Non-fatal — keeps the run going under the actual data we have.
      *
      * Fires regardless of whether StatsReader is bound. A misconfigured
-     * `stats_lookback_hours > bucket_ttl_seconds/3600` is still a misconfig
+     * `activity_lookback_hours > activity_bucket_ttl_seconds/3600` is still a misconfig
      * that operators should fix even if they haven't enabled stats yet
      * (silent until you do isn't helpful; alerting on the boundary now means
      * the next env that flips stats on starts clean).
@@ -382,12 +381,12 @@ final class CalibrateCommand extends Command
             return;
         }
 
-        $bucketTtlSeconds = Config::integer('lada-cache.stats.bucket_ttl_seconds', 86400 * 7);
+        $bucketTtlSeconds = Config::integer('lada-cache.calibration.activity_bucket_ttl_seconds', 86400 * 7);
         $bucketTtlHours = (int) floor($bucketTtlSeconds / 3600);
 
         if ($bucketTtlHours > 0 && $lookbackHours > $bucketTtlHours) {
             $this->warn(sprintf(
-                'stats_lookback_hours (%d) exceeds bucket retention (%d h); older buckets have expired and will read empty.',
+                'activity_lookback_hours (%d) exceeds bucket retention (%d h); older buckets have expired and will read empty.',
                 $lookbackHours,
                 $bucketTtlHours,
             ));
@@ -467,7 +466,7 @@ final class CalibrateCommand extends Command
      */
     private function resolveCurrentTtl(string $modelClass): int
     {
-        $calibrated = $this->repository->findForModel($modelClass);
+        $calibrated = $this->repository()->findForModel($modelClass);
 
         if ($calibrated !== null) {
             return $calibrated;
@@ -486,20 +485,13 @@ final class CalibrateCommand extends Command
     private function isIdleTimeSupported(): bool
     {
         try {
-            $client = $this->redis->getConnection()->client();
-            $result = $client->config('GET', 'maxmemory-policy');
+            $policy = $this->readRedisMaxmemoryPolicy();
 
-            // PhpRedis: ['maxmemory-policy' => 'noeviction'] | Predis: ['maxmemory-policy', 'noeviction']
-            if (! is_array($result)) {
-                // Non-array return (e.g. false) → CONFIG GET silently failed.
-                // Assume IDLETIME works but surface a warning so an LFU misconfiguration
-                // doesn't silently calibrate every TTL toward zero.
+            if ($policy === null) {
                 $this->warn('Could not determine Redis maxmemory-policy (CONFIG GET returned non-array). Proceeding under assumption that OBJECT IDLETIME is supported.');
 
                 return true;
             }
-
-            $policy = (string) ($result['maxmemory-policy'] ?? $result[1] ?? '');
 
             if ($policy === '') {
                 $this->warn('Redis maxmemory-policy not reported. Proceeding under assumption that OBJECT IDLETIME is supported.');
@@ -512,6 +504,28 @@ final class CalibrateCommand extends Command
             // CONFIG GET may be ACL-disabled in managed Redis; assume IDLETIME works.
             return true;
         }
+    }
+
+    private function readRedisMaxmemoryPolicy(): ?string
+    {
+        $client = $this->redis()->getConnection()->client();
+
+        if ($client instanceof \Redis) {
+            $result = $client->config('GET', 'maxmemory-policy');
+        } elseif (is_object($client) && is_callable([$client, 'config'])) {
+            $result = $client->{'config'}('GET', 'maxmemory-policy');
+        } else {
+            return null;
+        }
+
+        if (! is_array($result)) {
+            return null;
+        }
+
+        // PhpRedis: ['maxmemory-policy' => 'noeviction'] | Predis: ['maxmemory-policy', 'noeviction']
+        $policy = $result['maxmemory-policy'] ?? $result[1] ?? null;
+
+        return is_scalar($policy) ? (string) $policy : null;
     }
 
     /**
@@ -642,15 +656,16 @@ final class CalibrateCommand extends Command
     private function collectMetrics(string $tableName): array
     {
         $patterns = [
-            $this->redis->prefix('tags:database:*:table_specific:'.$tableName),
-            $this->redis->prefix('tags:database:*:table_unspecific:'.$tableName),
+            $this->redis()->prefix('tags:database:*:table_specific:'.$tableName),
+            $this->redis()->prefix('tags:database:*:table_unspecific:'.$tableName),
         ];
 
-        $connPrefix = (string) (config('database.redis.options.prefix') ?? '');
+        $rawConnectionPrefix = config('database.redis.options.prefix');
+        $connPrefix = is_string($rawConnectionPrefix) ? $rawConnectionPrefix : '';
         $idleTimes = [];
 
         foreach ($patterns as $pattern) {
-            foreach ($this->redis->scanKeys($pattern) as $batch) {
+            foreach ($this->redis()->scanKeys($pattern) as $batch) {
                 foreach ($batch as $tagKey) {
                     $tagKeyStripped = $connPrefix !== '' && str_starts_with($tagKey, $connPrefix)
                         ? substr($tagKey, strlen($connPrefix))
@@ -658,7 +673,7 @@ final class CalibrateCommand extends Command
 
                     // Stream the SET via SSCAN — large tag sets can hold millions of cache keys
                     // and a single SMEMBERS would block Redis and balloon client memory.
-                    foreach ($this->redis->sScanMembers($tagKeyStripped) as $memberBatch) {
+                    foreach ($this->redis()->sScanMembers($tagKeyStripped) as $memberBatch) {
                         foreach ($this->pipelinedIdleTimes($memberBatch) as $idle) {
                             $idleTimes[] = $idle;
                         }
@@ -684,7 +699,7 @@ final class CalibrateCommand extends Command
             return [];
         }
 
-        $client = $this->redis->getConnection()->client();
+        $client = $this->redis()->getConnection()->client();
         $idleTimes = [];
 
         foreach (array_chunk($keys, 100) as $chunk) {
@@ -732,18 +747,22 @@ final class CalibrateCommand extends Command
             $pipelineFlush = 'exec';
             $results = $client->{$pipelineFlush}();
 
-            return is_array($results) ? $results : [];
+            return is_array($results) ? array_values($results) : [];
         }
 
         // Predis: pipeline() takes a closure and returns ordered results.
         if (is_object($client) && method_exists($client, 'pipeline')) {
-            $results = $client->pipeline(static function ($pipe) use ($chunk): void {
+            $results = $client->pipeline(static function (object $pipe) use ($chunk): void {
+                if (! is_callable([$pipe, 'object'])) {
+                    return;
+                }
+
                 foreach ($chunk as $key) {
-                    $pipe->object('IDLETIME', $key);
+                    $pipe->{'object'}('IDLETIME', $key);
                 }
             });
 
-            return is_array($results) ? $results : [];
+            return is_array($results) ? array_values($results) : [];
         }
 
         // No pipeline API → sequential fallback.
@@ -751,11 +770,29 @@ final class CalibrateCommand extends Command
 
         foreach ($chunk as $key) {
             $results[] = is_object($client) && method_exists($client, 'object')
-                ? $client->object('IDLETIME', $key)
+                ? $client->{'object'}('IDLETIME', $key)
                 : null;
         }
 
         return $results;
+    }
+
+    private function redis(): Redis
+    {
+        if ($this->redis === null) {
+            throw new RuntimeException('Lada Cache calibration Redis dependency is not bound.');
+        }
+
+        return $this->redis;
+    }
+
+    private function repository(): TtlCalibrationRepository
+    {
+        if ($this->repository === null) {
+            throw new RuntimeException('Lada Cache calibration repository dependency is not bound.');
+        }
+
+        return $this->repository;
     }
 
     /**

--- a/src/Console/CalibrateCommand.php
+++ b/src/Console/CalibrateCommand.php
@@ -6,6 +6,7 @@ namespace Spiritix\LadaCache\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
@@ -111,10 +112,10 @@ final class CalibrateCommand extends Command
             return self::INVALID;
         }
 
-        $minSamples = (int) config('lada-cache.calibration.min_samples', 50);
+        $minSamples = Config::integer('lada-cache.calibration.min_samples', 50);
         $apply = (bool) $this->option('apply');
 
-        $lookbackHours = (int) config('lada-cache.calibration.stats_lookback_hours', 168);
+        $lookbackHours = Config::integer('lada-cache.calibration.stats_lookback_hours', 168);
         $this->warnIfLookbackExceedsBucketTtl($lookbackHours);
         // null  = stats signal unavailable (reader not configured OR Redis lookup failed);
         // []    = configured + reached Redis, but no activity recorded in window;
@@ -145,7 +146,7 @@ final class CalibrateCommand extends Command
 
         // Pending --apply rows are buffered and flushed in `$batchSize` chunks so we issue
         // O(models / batchSize) bulk UPSERTs instead of N single-row queries.
-        $batchSize = max(1, (int) config('lada-cache.calibration.batch_size', 100));
+        $batchSize = max(1, Config::integer('lada-cache.calibration.batch_size', 100));
         $pending = [];
 
         foreach ($models as $modelClass => $tableName) {
@@ -315,7 +316,7 @@ final class CalibrateCommand extends Command
             return [max($rawCalibrated, $floor), 'idletime_only'];
         }
 
-        $minReads = (int) config('lada-cache.calibration.min_reads_for_signal', 10);
+        $minReads = Config::integer('lada-cache.calibration.min_reads_for_signal', 10);
 
         // `empty` (Redis returned no events for this window) and `available`
         // but per-table reads+writes below the threshold collapse to the same
@@ -329,7 +330,7 @@ final class CalibrateCommand extends Command
         // Clamp negative configs to 0 defensively. A negative threshold would
         // make ($writes / $reads) >= $writeRatio universally true and collapse
         // every table to write_heavy in a single cron run.
-        $writeRatio = max(0.0, (float) config('lada-cache.calibration.write_heavy_ratio', 0.5));
+        $writeRatio = max(0.0, Config::float('lada-cache.calibration.write_heavy_ratio', 0.5));
 
         // reads=0 with writes>0 is degenerate (writes but no cache reads) — same
         // treatment as write-heavy: invalidation dominates, extending TTL is waste.
@@ -354,10 +355,10 @@ final class CalibrateCommand extends Command
         $adjusted = HitRatioAdjustment::apply(
             $rawCalibrated,
             $hitRatio,
-            (float) config('lada-cache.calibration.target_hit_ratio', 0.80),
-            (float) config('lada-cache.calibration.hit_ratio_deadband', 0.05),
-            (float) config('lada-cache.calibration.hit_ratio_learning_rate', 0.30),
-            (float) config('lada-cache.calibration.hit_ratio_max_step', 0.20),
+            Config::float('lada-cache.calibration.target_hit_ratio', 0.80),
+            Config::float('lada-cache.calibration.hit_ratio_deadband', 0.05),
+            Config::float('lada-cache.calibration.hit_ratio_learning_rate', 0.30),
+            Config::float('lada-cache.calibration.hit_ratio_max_step', 0.20),
         );
 
         return [max($adjusted, $floor), 'read_heavy'];
@@ -381,7 +382,7 @@ final class CalibrateCommand extends Command
             return;
         }
 
-        $bucketTtlSeconds = (int) config('lada-cache.stats.bucket_ttl_seconds', 86400 * 7);
+        $bucketTtlSeconds = Config::integer('lada-cache.stats.bucket_ttl_seconds', 86400 * 7);
         $bucketTtlHours = (int) floor($bucketTtlSeconds / 3600);
 
         if ($bucketTtlHours > 0 && $lookbackHours > $bucketTtlHours) {
@@ -456,7 +457,7 @@ final class CalibrateCommand extends Command
             return $value;
         }
 
-        return (float) config('lada-cache.calibration.safety_factor', 2.0);
+        return Config::float('lada-cache.calibration.safety_factor', 2.0);
     }
 
     /**
@@ -479,7 +480,7 @@ final class CalibrateCommand extends Command
             return (int) $modelTtls[$modelClass];
         }
 
-        return (int) config('lada-cache.expiration_time', 0);
+        return Config::integer('lada-cache.expiration_time', 0);
     }
 
     private function isIdleTimeSupported(): bool
@@ -694,7 +695,7 @@ final class CalibrateCommand extends Command
             }
 
             foreach ($raw as $idle) {
-                if ($idle === false || $idle === null) {
+                if (! is_numeric($idle)) {
                     continue;
                 }
 

--- a/src/Console/CalibrateCommand.php
+++ b/src/Console/CalibrateCommand.php
@@ -10,13 +10,16 @@ use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use ReflectionClass;
+use Spiritix\LadaCache\Calibration\HitRatioAdjustment;
 use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
 use Spiritix\LadaCache\Database\LadaCacheTrait;
 use Spiritix\LadaCache\Redis;
+use Spiritix\LadaCache\Stats\StatsReader;
 use Throwable;
 
 /**
- * Sample Redis OBJECT IDLETIME for Lada-cached models and derive per-model TTLs.
+ * Sample Redis OBJECT IDLETIME (and optionally StatsCounter activity) for
+ * Lada-cached models and derive per-model TTLs.
  *
  * Algorithm:
  *   1. Discover Eloquent models using LadaCacheTrait (or use --model=FQCN).
@@ -24,8 +27,17 @@ use Throwable;
  *      and `:table_unspecific:<table>` to enumerate cache keys for that table.
  *   3. Run OBJECT IDLETIME per key → seconds since last access (pipelined).
  *   4. Compute P50, P95, max of the distribution.
- *   5. calibrated_ttl = max(ceil(P95 × safety_factor), floor(previous_ttl / 2)).
- *   6. Skip models with samples < min_samples; persist only with --apply.
+ *   5. raw_calibrated = ceil(P95 × safety_factor).
+ *   6. Floor against survivor-bias: max(raw, previousTtl / 2).
+ *   7. (Opt-in) Read StatsCounter activity for the table over the last
+ *      `stats_lookback_hours` hours and adjust the TTL by signal:
+ *        - 'idletime_only' — StatsReader unavailable or lookback=0; original behavior.
+ *        - 'no_activity'   — reads+writes below `min_reads_for_signal`; original behavior.
+ *        - 'write_heavy'   — invalidates/(hits+misses) ≥ `write_heavy_ratio`;
+ *                            skip floor (raw_calibrated as-is), since invalidations
+ *                            dominate any TTL extension we'd grant.
+ *        - 'read_heavy'    — default activity path; hit-ratio proportional control.
+ *   8. Skip models with samples < min_samples; persist only with --apply.
  *
  * Safety:
  *   - Aborts when Redis maxmemory-policy is *-lfu (IDLETIME is unsupported there).
@@ -43,11 +55,12 @@ final class CalibrateCommand extends Command
                             {--models-path= : Override scanned directory (default: app_path("Models"))}
                             {--models-namespace= : Override scanned namespace (default: "App\\\\Models\\\\")}';
 
-    protected $description = 'Sample Redis OBJECT IDLETIME for Lada-cached models and compute per-model TTLs.';
+    protected $description = 'Sample Redis OBJECT IDLETIME (and optional activity counters) for Lada-cached models and compute per-model TTLs.';
 
     public function __construct(
         private readonly ?Redis $redis = null,
         private readonly ?TtlCalibrationRepository $repository = null,
+        private readonly ?StatsReader $statsReader = null,
     ) {
         parent::__construct();
     }
@@ -101,12 +114,26 @@ final class CalibrateCommand extends Command
         $minSamples = (int) config('lada-cache.calibration.min_samples', 50);
         $apply = (bool) $this->option('apply');
 
+        $lookbackHours = (int) config('lada-cache.calibration.stats_lookback_hours', 168);
+        $this->warnIfLookbackExceedsBucketTtl($lookbackHours);
+        // null  = stats signal unavailable (reader not configured OR Redis lookup failed);
+        // []    = configured + reached Redis, but no activity recorded in window;
+        // array = per-table activity counters.
+        // adjustForActivity uses the null/[] distinction to label the run
+        // 'idletime_only' vs 'no_activity' so monitoring can tell a real Redis
+        // outage from a cold cache window.
+        $activity = $this->loadActivity($lookbackHours);
+
         $rows = [];
         $counters = [
             'applied' => 0,
             'dry_run' => 0,
             'skipped_no_samples' => 0,
             'skipped_low_samples' => 0,
+            'signal_idletime_only' => 0,
+            'signal_no_activity' => 0,
+            'signal_read_heavy' => 0,
+            'signal_write_heavy' => 0,
         ];
 
         foreach ($models as $modelClass => $tableName) {
@@ -135,6 +162,9 @@ final class CalibrateCommand extends Command
                     '-',
                     '-',
                     '-',
+                    '-',
+                    '-',
+                    '-',
                     $metrics['samples'] === 0
                         ? 'skipped (no cache entries)'
                         : sprintf('skipped (< %d samples)', $minSamples),
@@ -151,13 +181,36 @@ final class CalibrateCommand extends Command
             // would monotonically shrink TTL toward zero. Floor at half the previous
             // effective TTL so each calibration can move at most one octave down.
             $floor = $previousTtl > 0 ? (int) floor($previousTtl / 2) : 0;
-            $calibratedTtl = max($rawCalibrated, $floor);
+
+            $tableActivity = $activity[$tableName] ?? ['hit' => 0, 'miss' => 0, 'invalidate' => 0];
+            $reads = $tableActivity['hit'] + $tableActivity['miss'];
+            $writes = $tableActivity['invalidate'];
+            // hit_ratio = hits / reads. null = reads=0 (no signal — don't feed adjustment).
+            // Sample threshold (min_reads_for_signal) is enforced in adjustForActivity;
+            // here we only guard against division-by-zero.
+            $hitRatio = $reads > 0 ? $tableActivity['hit'] / $reads : null;
+
+            [$calibratedTtl, $signalSource] = $this->adjustForActivity(
+                $rawCalibrated,
+                $floor,
+                $reads,
+                $writes,
+                $hitRatio,
+                statsAvailable: $activity !== null,
+            );
+
+            $counters['signal_'.$signalSource]++;
 
             $persistedMetrics = array_merge($metrics, [
                 'previous_ttl' => $previousTtl,
                 'raw_calibrated' => $rawCalibrated,
                 'floor' => $floor,
                 'safety_factor' => $safetyFactor,
+                'reads' => $reads,
+                'writes' => $writes,
+                'hit_ratio' => $hitRatio,
+                'signal_source' => $signalSource,
+                'lookback_hours' => $lookbackHours,
             ]);
 
             if ($apply) {
@@ -173,13 +226,16 @@ final class CalibrateCommand extends Command
                 $metrics['samples'],
                 $metrics['p50'],
                 $metrics['p95'],
+                $reads,
+                $writes,
+                $signalSource,
                 $calibratedTtl,
                 $apply ? 'applied' : 'dry-run',
             ];
         }
 
         $this->table(
-            ['Model', 'Table', 'Samples', 'P50 (s)', 'P95 (s)', 'TTL (s)', 'Status'],
+            ['Model', 'Table', 'Samples', 'P50 (s)', 'P95 (s)', 'Reads', 'Writes', 'Signal', 'TTL (s)', 'Status'],
             $rows,
         );
 
@@ -194,10 +250,149 @@ final class CalibrateCommand extends Command
             'mode' => $apply ? 'apply' : 'dry-run',
             'safety_factor' => $safetyFactor,
             'min_samples' => $minSamples,
+            'lookback_hours' => $lookbackHours,
             'models_total' => count($models),
         ]);
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Combine the IDLETIME-derived TTL with StatsCounter activity to pick a
+     * final value and label the signal source for downstream observability.
+     *
+     * $statsAvailable = false signals "Reader not configured OR Redis lookup
+     * failed" — both cases must be reported as 'idletime_only', not coalesced
+     * with the truly-empty-window 'no_activity' classification.
+     *
+     * On the read-heavy path, hit_ratio drives a convergent proportional
+     * controller that pulls TTL toward `target_hit_ratio`:
+     *   - adjustment = 1 + learning_rate × (target − actual)
+     *   - clamped to [1 − max_step, 1 + max_step] (bounded per-run change)
+     *   - |deviation| < deadband → no-op (oscillation guard around target)
+     *   - the survivor-bias floor still applies (previousTtl / 2)
+     * Combined, these three conditions form a bounded contraction map →
+     * geometric convergence to the target hit_ratio when IDLETIME is stable.
+     *
+     * @return array{0:int, 1:string} [adjustedTtl, signalSource]
+     */
+    private function adjustForActivity(int $rawCalibrated, int $floor, int $reads, int $writes, ?float $hitRatio, bool $statsAvailable): array
+    {
+        if (! $statsAvailable) {
+            return [max($rawCalibrated, $floor), 'idletime_only'];
+        }
+
+        $minReads = (int) config('lada-cache.calibration.min_reads_for_signal', 10);
+
+        if (($reads + $writes) < $minReads) {
+            // Too little observed traffic to draw a conclusion — preserve the
+            // IDLETIME-only behavior so we don't shrink TTLs on cold tables.
+            return [max($rawCalibrated, $floor), 'no_activity'];
+        }
+
+        // Clamp negative configs to 0 defensively. A negative threshold would
+        // make ($writes / $reads) >= $writeRatio universally true and collapse
+        // every table to write_heavy in a single cron run.
+        $writeRatio = max(0.0, (float) config('lada-cache.calibration.write_heavy_ratio', 0.5));
+
+        // reads=0 with writes>0 is degenerate (writes but no cache reads) — same
+        // treatment as write-heavy: invalidation dominates, extending TTL is waste.
+        $isWriteHeavy = $reads === 0
+            || ($writes > 0 && ($writes / $reads) >= $writeRatio);
+
+        if ($isWriteHeavy) {
+            // Skip the survivor-bias floor: writes are invalidating keys before
+            // their TTL fires anyway, so a longer TTL would only inflate memory
+            // without improving the hit ratio.
+            //
+            // BUT floor at 1: calibrated_ttl=0 means "persist forever" in Lada
+            // (Cache::set drops the EX argument), which is precisely the memory
+            // leak we want to avoid on write-heavy tables when an invalidation
+            // occasionally misses (raw SQL bypass, race, broken Observer, ...).
+            return [max($rawCalibrated, 1), 'write_heavy'];
+        }
+
+        // Read-heavy path — convergent hit_ratio proportional control.
+        // Adjustment is applied BEFORE floor; max(adj, floor) layers the
+        // hit_ratio signal on top without dropping the survivor-bias guard.
+        $adjusted = HitRatioAdjustment::apply(
+            $rawCalibrated,
+            $hitRatio,
+            (float) config('lada-cache.calibration.target_hit_ratio', 0.80),
+            (float) config('lada-cache.calibration.hit_ratio_deadband', 0.05),
+            (float) config('lada-cache.calibration.hit_ratio_learning_rate', 0.30),
+            (float) config('lada-cache.calibration.hit_ratio_max_step', 0.20),
+        );
+
+        return [max($adjusted, $floor), 'read_heavy'];
+    }
+
+    /**
+     * Surface a self-contradicting config where the operator asked us to look
+     * back further than StatsCounter retains data. Older buckets have already
+     * expired, so the pipeline reads return empty for the trailing keys.
+     * Non-fatal — keeps the run going under the actual data we have.
+     */
+    private function warnIfLookbackExceedsBucketTtl(int $lookbackHours): void
+    {
+        if ($lookbackHours <= 0 || $this->statsReader === null) {
+            return;
+        }
+
+        $bucketTtlSeconds = (int) config('lada-cache.stats.bucket_ttl_seconds', 86400 * 7);
+        $bucketTtlHours = (int) floor($bucketTtlSeconds / 3600);
+
+        if ($bucketTtlHours > 0 && $lookbackHours > $bucketTtlHours) {
+            $this->warn(sprintf(
+                'stats_lookback_hours (%d) exceeds bucket retention (%d h); older buckets have expired and will read empty.',
+                $lookbackHours,
+                $bucketTtlHours,
+            ));
+        }
+    }
+
+    /**
+     * One-shot activity load for the whole calibration run. Single pipelined
+     * Redis read for the lookback window.
+     *
+     * Returns:
+     *   - null  → stats signal unavailable: reader not configured, lookback=0,
+     *             OR Redis lookup threw. Caller labels these runs 'idletime_only'.
+     *   - []    → reached Redis, but no activity recorded in the window
+     *             (cold tables; operator hasn't enabled the counter yet).
+     *   - array → per-table activity counters.
+     *
+     * The null vs [] distinction matters: collapsing them would misclassify a
+     * Redis outage as "cold tables" and hide the failure from the signal
+     * counter histogram in the cron summary log.
+     *
+     * @return array<string, array{hit:int, miss:int, invalidate:int}>|null
+     */
+    private function loadActivity(int $lookbackHours): ?array
+    {
+        if ($this->statsReader === null || $lookbackHours <= 0) {
+            return null;
+        }
+
+        try {
+            return $this->statsReader->readAllActivity($lookbackHours);
+        } catch (Throwable $e) {
+            // Don't fail the whole calibration just because activity load broke.
+            // Operators still get the IDLETIME-driven TTL — they just lose the
+            // read/write adjustment for this run.
+            //
+            // report() so the exception lands in monitoring; cron stderr is
+            // often not captured by the scheduler in production deployments
+            // and a silent "warn" would mean we'd never know StatsReader is broken.
+            report($e);
+
+            $this->warn(sprintf(
+                'Activity stats unavailable (%s); falling back to IDLETIME-only signal.',
+                $e->getMessage(),
+            ));
+
+            return null;
+        }
     }
 
     /**
@@ -437,7 +632,7 @@ final class CalibrateCommand extends Command
      * instead of N synchronous calls. Falls back to sequential calls when the
      * underlying client does not expose a pipeline API.
      *
-     * @param  array<int, string> $keys
+     * @param  array<int, string>  $keys
      * @return array<int, int>
      */
     private function pipelinedIdleTimes(array $keys): array
@@ -472,7 +667,7 @@ final class CalibrateCommand extends Command
      * Issue OBJECT IDLETIME for each key in a single Redis pipeline round-trip
      * (PhpRedis or Predis). Returns raw command results aligned with input order.
      *
-     * @param  array<int, string> $chunk
+     * @param  array<int, string>  $chunk
      * @return array<int, mixed>
      */
     private function runIdleTimeBatch(mixed $client, array $chunk): array
@@ -515,7 +710,7 @@ final class CalibrateCommand extends Command
     }
 
     /**
-     * @param  array<int, int>                               $values
+     * @param  array<int, int>  $values
      * @return array{samples:int, p50:int, p95:int, max:int}
      */
     private function computePercentiles(array $values): array
@@ -537,7 +732,7 @@ final class CalibrateCommand extends Command
     }
 
     /**
-     * @param array<int, int> $sortedValues
+     * @param  array<int, int>  $sortedValues
      */
     private function percentile(array $sortedValues, int $percentile): int
     {

--- a/src/Console/CalibrateCommand.php
+++ b/src/Console/CalibrateCommand.php
@@ -60,16 +60,20 @@ final class CalibrateCommand extends Command
             return self::SUCCESS;
         }
 
-        if ($this->redis === null || $this->repository === null) {
-            $this->error('Lada Cache calibration dependencies are not bound. Check service provider registration.');
-
-            return self::FAILURE;
-        }
-
+        // Calibration kapalıyken erken çık — ServiceProvider deps bind etmemiş olabilir
+        // (zero-arg singleton path). Önce flag, sonra deps null kontrolü; yoksa
+        // calibration.enabled=false default değerinde manuel
+        // `php artisan lada-cache:calibrate` çağrısı FAILURE ile düşer.
         if (! (bool) config('lada-cache.calibration.enabled', false)) {
             $this->warn('Lada Cache calibration is disabled. Set LADA_CACHE_CALIBRATION_ENABLED=true to enable.');
 
             return self::SUCCESS;
+        }
+
+        if ($this->redis === null || $this->repository === null) {
+            $this->error('Lada Cache calibration dependencies are not bound. Check service provider registration.');
+
+            return self::FAILURE;
         }
 
         if (! $this->isIdleTimeSupported()) {

--- a/src/Console/CalibrateCommand.php
+++ b/src/Console/CalibrateCommand.php
@@ -1,0 +1,550 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+use ReflectionClass;
+use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
+use Spiritix\LadaCache\Database\LadaCacheTrait;
+use Spiritix\LadaCache\Redis;
+use Throwable;
+
+/**
+ * Sample Redis OBJECT IDLETIME for Lada-cached models and derive per-model TTLs.
+ *
+ * Algorithm:
+ *   1. Discover Eloquent models using LadaCacheTrait (or use --model=FQCN).
+ *   2. For each model, SCAN tag sets `lada:tags:database:*:table_specific:<table>`
+ *      and `:table_unspecific:<table>` to enumerate cache keys for that table.
+ *   3. Run OBJECT IDLETIME per key → seconds since last access (pipelined).
+ *   4. Compute P50, P95, max of the distribution.
+ *   5. calibrated_ttl = max(ceil(P95 × safety_factor), floor(previous_ttl / 2)).
+ *   6. Skip models with samples < min_samples; persist only with --apply.
+ *
+ * Safety:
+ *   - Aborts when Redis maxmemory-policy is *-lfu (IDLETIME is unsupported there).
+ *   - Tolerates orphan SET members (cache key deleted, tag membership lingering).
+ *   - Dry-run by default; --apply mutates the lada_cache_calibrations table only.
+ *
+ * Designed for periodic cron use. Reads Redis metadata only (no key mutation).
+ */
+final class CalibrateCommand extends Command
+{
+    protected $signature = 'lada-cache:calibrate
+                            {--apply : Persist calibrated TTLs (default: dry-run)}
+                            {--model= : Only calibrate the given fully-qualified model class}
+                            {--safety-factor= : Override config safety_factor (P95 multiplier)}
+                            {--models-path= : Override scanned directory (default: app_path("Models"))}
+                            {--models-namespace= : Override scanned namespace (default: "App\\\\Models\\\\")}';
+
+    protected $description = 'Sample Redis OBJECT IDLETIME for Lada-cached models and compute per-model TTLs.';
+
+    public function __construct(
+        private readonly ?Redis $redis = null,
+        private readonly ?TtlCalibrationRepository $repository = null,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! (bool) config('lada-cache.active', true)) {
+            $this->warn('Lada Cache is disabled — nothing to calibrate.');
+
+            return self::SUCCESS;
+        }
+
+        if ($this->redis === null || $this->repository === null) {
+            $this->error('Lada Cache calibration dependencies are not bound. Check service provider registration.');
+
+            return self::FAILURE;
+        }
+
+        if (! (bool) config('lada-cache.calibration.enabled', false)) {
+            $this->warn('Lada Cache calibration is disabled. Set LADA_CACHE_CALIBRATION_ENABLED=true to enable.');
+
+            return self::SUCCESS;
+        }
+
+        if (! $this->isIdleTimeSupported()) {
+            $this->error('Redis uses an LFU eviction policy; OBJECT IDLETIME is unavailable. Calibration aborted.');
+
+            return self::FAILURE;
+        }
+
+        $models = $this->discoverModels();
+
+        if ($models === []) {
+            $this->warn('No models using LadaCacheTrait were discovered.');
+
+            return self::SUCCESS;
+        }
+
+        try {
+            $safetyFactor = $this->resolveSafetyFactor();
+        } catch (InvalidArgumentException $e) {
+            $this->error($e->getMessage());
+
+            return self::INVALID;
+        }
+
+        $minSamples = (int) config('lada-cache.calibration.min_samples', 50);
+        $apply = (bool) $this->option('apply');
+
+        $rows = [];
+        $counters = [
+            'applied' => 0,
+            'dry_run' => 0,
+            'skipped_no_samples' => 0,
+            'skipped_low_samples' => 0,
+        ];
+
+        foreach ($models as $modelClass => $tableName) {
+            $metrics = $this->collectMetrics($tableName);
+
+            // Defensive: even when min_samples is misconfigured to 0, never persist
+            // a row with zero samples — calibrated_ttl would be 0 which means
+            // "persist forever" and that's never what we want from an empty signal.
+            if ($metrics['samples'] === 0 || $metrics['samples'] < $minSamples) {
+                if ($metrics['samples'] === 0) {
+                    $counters['skipped_no_samples']++;
+                    // Log so operators can distinguish "model rarely used" from "table name
+                    // mismatch / discovery bug" — both surface as 'skipped' in the output.
+                    Log::info('[lada-cache:calibrate] No cache entries discovered for model.', [
+                        'model' => $modelClass,
+                        'table' => $tableName,
+                    ]);
+                } else {
+                    $counters['skipped_low_samples']++;
+                }
+
+                $rows[] = [
+                    $modelClass,
+                    $tableName,
+                    $metrics['samples'],
+                    '-',
+                    '-',
+                    '-',
+                    $metrics['samples'] === 0
+                        ? 'skipped (no cache entries)'
+                        : sprintf('skipped (< %d samples)', $minSamples),
+                ];
+
+                continue;
+            }
+
+            $rawCalibrated = (int) ceil($metrics['p95'] * $safetyFactor);
+            $previousTtl = $this->resolveCurrentTtl($modelClass);
+
+            // Survivor-bias guard: OBJECT IDLETIME can only sample keys still alive,
+            // so P95 is always ≤ current TTL. Without a floor, repeated cron runs
+            // would monotonically shrink TTL toward zero. Floor at half the previous
+            // effective TTL so each calibration can move at most one octave down.
+            $floor = $previousTtl > 0 ? (int) floor($previousTtl / 2) : 0;
+            $calibratedTtl = max($rawCalibrated, $floor);
+
+            $persistedMetrics = array_merge($metrics, [
+                'previous_ttl' => $previousTtl,
+                'raw_calibrated' => $rawCalibrated,
+                'floor' => $floor,
+                'safety_factor' => $safetyFactor,
+            ]);
+
+            if ($apply) {
+                $this->repository->upsert($modelClass, $tableName, $calibratedTtl, $persistedMetrics);
+                $counters['applied']++;
+            } else {
+                $counters['dry_run']++;
+            }
+
+            $rows[] = [
+                $modelClass,
+                $tableName,
+                $metrics['samples'],
+                $metrics['p50'],
+                $metrics['p95'],
+                $calibratedTtl,
+                $apply ? 'applied' : 'dry-run',
+            ];
+        }
+
+        $this->table(
+            ['Model', 'Table', 'Samples', 'P50 (s)', 'P95 (s)', 'TTL (s)', 'Status'],
+            $rows,
+        );
+
+        $this->info($apply
+            ? 'Calibration persisted. TTL resolver will pick up new values on next read.'
+            : 'Dry-run complete. Re-run with --apply to persist.');
+
+        // Summary log for cron-style monitoring (Sentry, Horizon, log aggregator).
+        // Operators can alert on sudden drops in `applied` or spikes in `skipped_no_samples`
+        // without parsing console output.
+        Log::info('[lada-cache:calibrate] Run summary', $counters + [
+            'mode' => $apply ? 'apply' : 'dry-run',
+            'safety_factor' => $safetyFactor,
+            'min_samples' => $minSamples,
+            'models_total' => count($models),
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @throws InvalidArgumentException when an explicit --safety-factor <= 0 is supplied.
+     */
+    private function resolveSafetyFactor(): float
+    {
+        $override = $this->option('safety-factor');
+
+        if ($override !== null && is_numeric($override)) {
+            $value = (float) $override;
+
+            if ($value <= 0.0) {
+                throw new InvalidArgumentException(
+                    'safety-factor must be > 0 (got '.$override.'); negative/zero would produce nonsensical TTLs.',
+                );
+            }
+
+            return $value;
+        }
+
+        return (float) config('lada-cache.calibration.safety_factor', 2.0);
+    }
+
+    /**
+     * Effective TTL currently in force for the given model class.
+     * Walks the same resolution chain TtlResolver uses, minus the HasLadaTtl interface
+     * (which depends on a Model instance — not relevant when we just need a floor).
+     */
+    private function resolveCurrentTtl(string $modelClass): int
+    {
+        $calibrated = $this->repository->findForModel($modelClass);
+
+        if ($calibrated !== null) {
+            return $calibrated;
+        }
+
+        /** @var array<class-string, ?int> $modelTtls */
+        $modelTtls = (array) config('lada-cache.model_ttls', []);
+
+        if (array_key_exists($modelClass, $modelTtls) && $modelTtls[$modelClass] !== null) {
+            return (int) $modelTtls[$modelClass];
+        }
+
+        return (int) config('lada-cache.expiration_time', 0);
+    }
+
+    private function isIdleTimeSupported(): bool
+    {
+        try {
+            $client = $this->redis->getConnection()->client();
+            $result = $client->config('GET', 'maxmemory-policy');
+
+            // PhpRedis: ['maxmemory-policy' => 'noeviction'] | Predis: ['maxmemory-policy', 'noeviction']
+            if (! is_array($result)) {
+                // Non-array return (e.g. false) → CONFIG GET silently failed.
+                // Assume IDLETIME works but surface a warning so an LFU misconfiguration
+                // doesn't silently calibrate every TTL toward zero.
+                $this->warn('Could not determine Redis maxmemory-policy (CONFIG GET returned non-array). Proceeding under assumption that OBJECT IDLETIME is supported.');
+
+                return true;
+            }
+
+            $policy = (string) ($result['maxmemory-policy'] ?? $result[1] ?? '');
+
+            if ($policy === '') {
+                $this->warn('Redis maxmemory-policy not reported. Proceeding under assumption that OBJECT IDLETIME is supported.');
+
+                return true;
+            }
+
+            return ! str_contains(strtolower($policy), 'lfu');
+        } catch (Throwable) {
+            // CONFIG GET may be ACL-disabled in managed Redis; assume IDLETIME works.
+            return true;
+        }
+    }
+
+    /**
+     * @return array<class-string<Model>, string>
+     */
+    private function discoverModels(): array
+    {
+        $explicit = $this->option('model');
+
+        if (is_string($explicit) && $explicit !== '') {
+            return $this->resolveSingleModel($explicit);
+        }
+
+        $modelsPath = $this->resolveModelsPath();
+        $namespace = $this->resolveModelsNamespace();
+
+        $models = [];
+
+        if (! is_dir($modelsPath)) {
+            return [];
+        }
+
+        foreach (File::allFiles($modelsPath) as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $class = $this->classFromPath($file->getPathname(), $modelsPath, $namespace);
+
+            if ($class === null || ! class_exists($class)) {
+                continue;
+            }
+
+            if (! is_subclass_of($class, Model::class)) {
+                continue;
+            }
+
+            $reflection = new ReflectionClass($class);
+
+            if ($reflection->isAbstract()) {
+                continue;
+            }
+
+            if (! in_array(LadaCacheTrait::class, class_uses_recursive($class), true)) {
+                continue;
+            }
+
+            try {
+                /** @var Model $instance */
+                $instance = $reflection->newInstanceWithoutConstructor();
+                $models[$class] = $instance->getTable();
+            } catch (Throwable) {
+                continue;
+            }
+        }
+
+        ksort($models);
+
+        return $models;
+    }
+
+    private function resolveModelsPath(): string
+    {
+        $override = $this->option('models-path');
+
+        if (is_string($override) && $override !== '') {
+            return $override;
+        }
+
+        return app_path('Models');
+    }
+
+    private function resolveModelsNamespace(): string
+    {
+        $override = $this->option('models-namespace');
+
+        if (is_string($override) && $override !== '') {
+            return rtrim($override, '\\').'\\';
+        }
+
+        return 'App\\Models\\';
+    }
+
+    /**
+     * @return array<class-string<Model>, string>
+     */
+    private function resolveSingleModel(string $modelClass): array
+    {
+        if (! class_exists($modelClass)) {
+            $this->error(sprintf('Model class %s does not exist.', $modelClass));
+
+            return [];
+        }
+
+        if (! is_subclass_of($modelClass, Model::class)) {
+            $this->error(sprintf('%s is not an Eloquent model.', $modelClass));
+
+            return [];
+        }
+
+        if (! in_array(LadaCacheTrait::class, class_uses_recursive($modelClass), true)) {
+            $this->error(sprintf('%s does not use LadaCacheTrait.', $modelClass));
+
+            return [];
+        }
+
+        /** @var Model $instance */
+        $instance = (new ReflectionClass($modelClass))->newInstanceWithoutConstructor();
+
+        return [$modelClass => $instance->getTable()];
+    }
+
+    private function classFromPath(string $path, string $basePath, string $namespace): ?string
+    {
+        $relative = ltrim(str_replace($basePath, '', $path), DIRECTORY_SEPARATOR);
+        $withoutExt = preg_replace('/\.php$/', '', $relative);
+
+        if ($withoutExt === null || $withoutExt === '') {
+            return null;
+        }
+
+        return $namespace.str_replace(DIRECTORY_SEPARATOR, '\\', $withoutExt);
+    }
+
+    /**
+     * @return array{samples:int, p50:int, p95:int, max:int}
+     */
+    private function collectMetrics(string $tableName): array
+    {
+        $patterns = [
+            $this->redis->prefix('tags:database:*:table_specific:'.$tableName),
+            $this->redis->prefix('tags:database:*:table_unspecific:'.$tableName),
+        ];
+
+        $connPrefix = (string) (config('database.redis.options.prefix') ?? '');
+        $idleTimes = [];
+
+        foreach ($patterns as $pattern) {
+            foreach ($this->redis->scanKeys($pattern) as $batch) {
+                foreach ($batch as $tagKey) {
+                    $tagKeyStripped = $connPrefix !== '' && str_starts_with($tagKey, $connPrefix)
+                        ? substr($tagKey, strlen($connPrefix))
+                        : $tagKey;
+
+                    // Stream the SET via SSCAN — large tag sets can hold millions of cache keys
+                    // and a single SMEMBERS would block Redis and balloon client memory.
+                    foreach ($this->redis->sScanMembers($tagKeyStripped) as $memberBatch) {
+                        foreach ($this->pipelinedIdleTimes($memberBatch) as $idle) {
+                            $idleTimes[] = $idle;
+                        }
+                    }
+                }
+            }
+        }
+
+        return $this->computePercentiles($idleTimes);
+    }
+
+    /**
+     * Run OBJECT IDLETIME for a batch of keys using a single Redis pipeline round-trip
+     * instead of N synchronous calls. Falls back to sequential calls when the
+     * underlying client does not expose a pipeline API.
+     *
+     * @param  array<int, string> $keys
+     * @return array<int, int>
+     */
+    private function pipelinedIdleTimes(array $keys): array
+    {
+        if ($keys === []) {
+            return [];
+        }
+
+        $client = $this->redis->getConnection()->client();
+        $idleTimes = [];
+
+        foreach (array_chunk($keys, 100) as $chunk) {
+            try {
+                $raw = $this->runIdleTimeBatch($client, $chunk);
+            } catch (Throwable) {
+                continue;
+            }
+
+            foreach ($raw as $idle) {
+                if ($idle === false || $idle === null) {
+                    continue;
+                }
+
+                $idleTimes[] = (int) $idle;
+            }
+        }
+
+        return $idleTimes;
+    }
+
+    /**
+     * Issue OBJECT IDLETIME for each key in a single Redis pipeline round-trip
+     * (PhpRedis or Predis). Returns raw command results aligned with input order.
+     *
+     * @param  array<int, string> $chunk
+     * @return array<int, mixed>
+     */
+    private function runIdleTimeBatch(mixed $client, array $chunk): array
+    {
+        // PhpRedis: pipeline() switches the client into queue mode; the flush call
+        // returns results in order. Each queued command returns $client (not the value).
+        if ($client instanceof \Redis) {
+            $client->pipeline();
+
+            foreach ($chunk as $key) {
+                $client->object('IDLETIME', $key);
+            }
+
+            $results = $client->{'exec'}();
+
+            return is_array($results) ? $results : [];
+        }
+
+        // Predis: pipeline() takes a closure and returns ordered results.
+        if (is_object($client) && method_exists($client, 'pipeline')) {
+            $results = $client->pipeline(static function ($pipe) use ($chunk): void {
+                foreach ($chunk as $key) {
+                    $pipe->object('IDLETIME', $key);
+                }
+            });
+
+            return is_array($results) ? $results : [];
+        }
+
+        // No pipeline API → sequential fallback.
+        $results = [];
+
+        foreach ($chunk as $key) {
+            $results[] = is_object($client) && method_exists($client, 'object')
+                ? $client->object('IDLETIME', $key)
+                : null;
+        }
+
+        return $results;
+    }
+
+    /**
+     * @param  array<int, int>                               $values
+     * @return array{samples:int, p50:int, p95:int, max:int}
+     */
+    private function computePercentiles(array $values): array
+    {
+        $samples = count($values);
+
+        if ($samples === 0) {
+            return ['samples' => 0, 'p50' => 0, 'p95' => 0, 'max' => 0];
+        }
+
+        sort($values);
+
+        return [
+            'samples' => $samples,
+            'p50' => $this->percentile($values, 50),
+            'p95' => $this->percentile($values, 95),
+            'max' => $values[$samples - 1],
+        ];
+    }
+
+    /**
+     * @param array<int, int> $sortedValues
+     */
+    private function percentile(array $sortedValues, int $percentile): int
+    {
+        $count = count($sortedValues);
+
+        if ($count === 0) {
+            return 0;
+        }
+
+        $index = (int) ceil(($percentile / 100) * $count) - 1;
+
+        return $sortedValues[max(0, min($index, $count - 1))];
+    }
+}

--- a/src/Console/CalibrateCommand.php
+++ b/src/Console/CalibrateCommand.php
@@ -143,6 +143,11 @@ final class CalibrateCommand extends Command
             'signal_write_heavy' => 0,
         ];
 
+        // Pending --apply rows are buffered and flushed in `$batchSize` chunks so we issue
+        // O(models / batchSize) bulk UPSERTs instead of N single-row queries.
+        $batchSize = max(1, (int) config('lada-cache.calibration.batch_size', 100));
+        $pending = [];
+
         foreach ($models as $modelClass => $tableName) {
             $metrics = $this->collectMetrics($tableName);
 
@@ -221,7 +226,18 @@ final class CalibrateCommand extends Command
             ]);
 
             if ($apply) {
-                $this->repository->upsert($modelClass, $tableName, $calibratedTtl, $persistedMetrics);
+                $pending[] = [
+                    'model_class' => $modelClass,
+                    'table_name' => $tableName,
+                    'calibrated_ttl' => $calibratedTtl,
+                    'metrics' => $persistedMetrics,
+                ];
+
+                if (count($pending) >= $batchSize) {
+                    $this->repository->upsertMany($pending);
+                    $pending = [];
+                }
+
                 $counters['applied']++;
             } else {
                 $counters['dry_run']++;
@@ -239,6 +255,11 @@ final class CalibrateCommand extends Command
                 $calibratedTtl,
                 $apply ? 'applied' : 'dry-run',
             ];
+        }
+
+        // Residual rows that didn't fill the final batch.
+        if ($pending !== []) {
+            $this->repository->upsertMany($pending);
         }
 
         $this->table(

--- a/src/Console/CalibrateCommand.php
+++ b/src/Console/CalibrateCommand.php
@@ -119,10 +119,17 @@ final class CalibrateCommand extends Command
         // null  = stats signal unavailable (reader not configured OR Redis lookup failed);
         // []    = configured + reached Redis, but no activity recorded in window;
         // array = per-table activity counters.
-        // adjustForActivity uses the null/[] distinction to label the run
-        // 'idletime_only' vs 'no_activity' so monitoring can tell a real Redis
-        // outage from a cold cache window.
+        // We collapse the tri-state into an explicit `$statsState` enum-like
+        // string so downstream branches read straightforwardly; the original
+        // null/[] distinction below is what monitoring needs to tell a real
+        // Redis outage ('unavailable' → 'idletime_only') from a cold window
+        // ('empty' → 'no_activity').
         $activity = $this->loadActivity($lookbackHours);
+        $statsState = match (true) {
+            $activity === null => 'unavailable',
+            $activity === [] => 'empty',
+            default => 'available',
+        };
 
         $rows = [];
         $counters = [
@@ -196,7 +203,7 @@ final class CalibrateCommand extends Command
                 $reads,
                 $writes,
                 $hitRatio,
-                statsAvailable: $activity !== null,
+                statsState: $statsState,
             );
 
             $counters['signal_'.$signalSource]++;
@@ -261,9 +268,13 @@ final class CalibrateCommand extends Command
      * Combine the IDLETIME-derived TTL with StatsCounter activity to pick a
      * final value and label the signal source for downstream observability.
      *
-     * $statsAvailable = false signals "Reader not configured OR Redis lookup
-     * failed" — both cases must be reported as 'idletime_only', not coalesced
-     * with the truly-empty-window 'no_activity' classification.
+     * `$statsState` is the explicit tri-state from {@see handle()}:
+     *   - 'unavailable' → reader not configured OR Redis lookup failed; report
+     *                     as 'idletime_only' so monitoring sees the outage.
+     *   - 'empty'       → reader reached Redis but the window held no events
+     *                     for any table (also yields 'no_activity' when per-table
+     *                     reads+writes is under the signal threshold).
+     *   - 'available'   → per-table activity present; the real adjustment runs.
      *
      * On the read-heavy path, hit_ratio drives a convergent proportional
      * controller that pulls TTL toward `target_hit_ratio`:
@@ -274,17 +285,21 @@ final class CalibrateCommand extends Command
      * Combined, these three conditions form a bounded contraction map →
      * geometric convergence to the target hit_ratio when IDLETIME is stable.
      *
+     * @param  'unavailable'|'empty'|'available'  $statsState
      * @return array{0:int, 1:string} [adjustedTtl, signalSource]
      */
-    private function adjustForActivity(int $rawCalibrated, int $floor, int $reads, int $writes, ?float $hitRatio, bool $statsAvailable): array
+    private function adjustForActivity(int $rawCalibrated, int $floor, int $reads, int $writes, ?float $hitRatio, string $statsState): array
     {
-        if (! $statsAvailable) {
+        if ($statsState === 'unavailable') {
             return [max($rawCalibrated, $floor), 'idletime_only'];
         }
 
         $minReads = (int) config('lada-cache.calibration.min_reads_for_signal', 10);
 
-        if (($reads + $writes) < $minReads) {
+        // `empty` (Redis returned no events for this window) and `available`
+        // but per-table reads+writes below the threshold collapse to the same
+        // 'no_activity' label — we have insufficient evidence either way.
+        if ($statsState === 'empty' || ($reads + $writes) < $minReads) {
             // Too little observed traffic to draw a conclusion — preserve the
             // IDLETIME-only behavior so we don't shrink TTLs on cold tables.
             return [max($rawCalibrated, $floor), 'no_activity'];
@@ -332,10 +347,16 @@ final class CalibrateCommand extends Command
      * back further than StatsCounter retains data. Older buckets have already
      * expired, so the pipeline reads return empty for the trailing keys.
      * Non-fatal — keeps the run going under the actual data we have.
+     *
+     * Fires regardless of whether StatsReader is bound. A misconfigured
+     * `stats_lookback_hours > bucket_ttl_seconds/3600` is still a misconfig
+     * that operators should fix even if they haven't enabled stats yet
+     * (silent until you do isn't helpful; alerting on the boundary now means
+     * the next env that flips stats on starts clean).
      */
     private function warnIfLookbackExceedsBucketTtl(int $lookbackHours): void
     {
-        if ($lookbackHours <= 0 || $this->statsReader === null) {
+        if ($lookbackHours <= 0) {
             return;
         }
 
@@ -681,7 +702,13 @@ final class CalibrateCommand extends Command
                 $client->object('IDLETIME', $key);
             }
 
-            $results = $client->{'exec'}();
+            // Dynamic method call below — phpredis exposes the pipeline flush
+            // as a PHP reserved word, and some static analyzers (psalm /
+            // phpstan strict modes) trip on direct calls even though the
+            // method is real. The dynamic form sidesteps that false positive
+            // without changing behavior.
+            $pipelineFlush = 'exec';
+            $results = $client->{$pipelineFlush}();
 
             return is_array($results) ? $results : [];
         }

--- a/src/Contracts/HasLadaTtl.php
+++ b/src/Contracts/HasLadaTtl.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Contracts;
+
+/**
+ * Marker interface for Eloquent models that want to override the default Lada Cache TTL.
+ *
+ * Implementing this on a model lets the cache layer apply a per-model TTL instead of
+ * the global config('lada-cache.expiration_time'). Resolution order is:
+ *   1. Model::getLadaTtl() (this interface)
+ *   2. config('lada-cache.model_ttls.<ClassName>')
+ *   3. global config('lada-cache.expiration_time')
+ *
+ * Semantics of the returned value:
+ *   - null : defer to config-level fallback (model_ttls or global)
+ *   - > 0  : TTL in seconds (e.g., 3600 = 1 hour)
+ *   - 0    : persist forever (cache until tag-based invalidation) — same as
+ *            setting global expiration_time to 0
+ *   - < 0  : same as 0 (forever) — discouraged, prefer 0
+ */
+interface HasLadaTtl
+{
+    public function getLadaTtl(): ?int;
+}

--- a/src/Database/SqliteConnection.php
+++ b/src/Database/SqliteConnection.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Spiritix\LadaCache\Database;
 
-use Illuminate\Database\SqliteConnection as BaseSqliteConnection;
+use Illuminate\Database\SQLiteConnection as BaseSqliteConnection;
 use Spiritix\LadaCache\QueryHandler as LadaQueryHandler;
 
 /**

--- a/src/Events/LadaCacheActivity.php
+++ b/src/Events/LadaCacheActivity.php
@@ -10,22 +10,11 @@ namespace Spiritix\LadaCache\Events;
  * Lightweight hook so listeners can collect per-table cache counters without
  * forcing every install to pay for the dispatch on the hot path.
  *
- * Activation: requires `lada-cache.events.enabled = true` (defaults to false
- * so unused installs incur zero overhead).
+ * Activation follows `lada-cache.calibration.enabled` so unused installs incur
+ * zero overhead.
  *
- * Example listener:
- *
- *   Event::listen(LadaCacheActivity::class, function (LadaCacheActivity $e): void {
- *       app('redis')->hincrby(
- *           'lada:metrics:'.$e->action,
- *           $e->table ?? 'unknown',
- *           1,
- *       );
- *   });
- *
- * See LadaCacheServiceProvider for listener wiring (StatsCounter is the
- * bundled production-ready listener; CalibrateCommand consumes the resulting
- * per-table HASH buckets via StatsReader).
+ * See LadaCacheServiceProvider for listener wiring. CalibrateCommand consumes
+ * the resulting per-table HASH buckets through the internal reader.
  */
 final class LadaCacheActivity
 {

--- a/src/Events/LadaCacheActivity.php
+++ b/src/Events/LadaCacheActivity.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Spiritix\LadaCache\Events;
 
-use Spiritix\LadaCache\Console\CalibrateCommand;
-use Spiritix\LadaCache\Stats\StatsCounter;
-
 /**
  * Lada Cache activity event — dispatched on cache hit / miss / invalidate.
  *
@@ -26,9 +23,9 @@ use Spiritix\LadaCache\Stats\StatsCounter;
  *       );
  *   });
  *
- * The bundled {@see StatsCounter} listener provides a
- * production-ready buffered counter that periodically writes per-table HASH
- * buckets to Redis — useful as a calibrate-time input to {@see CalibrateCommand}.
+ * See LadaCacheServiceProvider for listener wiring (StatsCounter is the
+ * bundled production-ready listener; CalibrateCommand consumes the resulting
+ * per-table HASH buckets via StatsReader).
  */
 final class LadaCacheActivity
 {

--- a/src/Events/LadaCacheActivity.php
+++ b/src/Events/LadaCacheActivity.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Events;
+
+use Spiritix\LadaCache\Console\CalibrateCommand;
+use Spiritix\LadaCache\Stats\StatsCounter;
+
+/**
+ * Lada Cache activity event — dispatched on cache hit / miss / invalidate.
+ *
+ * Lightweight hook so listeners can collect per-table cache counters without
+ * forcing every install to pay for the dispatch on the hot path.
+ *
+ * Activation: requires `lada-cache.events.enabled = true` (defaults to false
+ * so unused installs incur zero overhead).
+ *
+ * Example listener:
+ *
+ *   Event::listen(LadaCacheActivity::class, function (LadaCacheActivity $e): void {
+ *       app('redis')->hincrby(
+ *           'lada:metrics:'.$e->action,
+ *           $e->table ?? 'unknown',
+ *           1,
+ *       );
+ *   });
+ *
+ * The bundled {@see StatsCounter} listener provides a
+ * production-ready buffered counter that periodically writes per-table HASH
+ * buckets to Redis — useful as a calibrate-time input to {@see CalibrateCommand}.
+ */
+final class LadaCacheActivity
+{
+    /**
+     * @param  string  $action  One of: hit, miss, invalidate.
+     * @param  string  $key  Cache key (empty string for invalidate-by-tag).
+     * @param  array<string>  $tags  Tags associated with the operation.
+     * @param  string|null  $table  Primary table for the operation, when known.
+     */
+    public function __construct(
+        public readonly string $action,
+        public readonly string $key,
+        public readonly array $tags,
+        public readonly ?string $table = null,
+    ) {}
+
+    public function isHit(): bool
+    {
+        return $this->action === 'hit';
+    }
+
+    public function isMiss(): bool
+    {
+        return $this->action === 'miss';
+    }
+}

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -15,6 +15,7 @@ use Illuminate\Database\MySqlConnection;
 use Illuminate\Database\PostgresConnection;
 use Illuminate\Database\SqliteConnection;
 use Illuminate\Database\SqlServerConnection;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Octane\Events\RequestHandled;
@@ -99,11 +100,9 @@ final class LadaCacheServiceProvider extends ServiceProvider
             $cache->flush();
         });
 
-        // Wire StatsCounter as a listener for LadaCacheActivity events when both
-        // event dispatch AND stats collection are enabled. The counter buffers
-        // in process memory and flushes either on threshold or at app shutdown.
-        if ((bool) config('lada-cache.events.enabled', false)
-            && (bool) config('lada-cache.stats.enabled', false)) {
+        // Calibration records lightweight per-table activity while enabled so
+        // lada-cache:calibrate can adjust TTLs with recent read/write signals.
+        if ((bool) config('lada-cache.calibration.enabled', false)) {
             $events->listen(LadaCacheActivity::class, static function (LadaCacheActivity $event): void {
                 /** @var StatsCounter $counter */
                 $counter = app('lada.stats_counter');
@@ -152,24 +151,25 @@ final class LadaCacheServiceProvider extends ServiceProvider
             }
         }
 
-        // Auto-register the calibration cron when enabled and a schedule expression is set.
+        // Auto-register the calibration command when enabled and schedule_interval > 0.
         // Uses callAfterResolving so we don't force the Schedule kernel to boot unnecessarily —
         // it fires only when the framework itself resolves the scheduler (artisan schedule:* etc).
-        // To opt out, set config('lada-cache.calibration.schedule') to an empty string and call
+        // To opt out, set config('lada-cache.calibration.schedule_interval') to 0 and call
         // Schedule::command(...) yourself in routes/console.php instead.
         $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
             if (! (bool) config('lada-cache.calibration.enabled', false)) {
                 return;
             }
 
-            $cron = trim((string) config('lada-cache.calibration.schedule', ''));
+            $scheduleInterval = Config::integer('lada-cache.calibration.schedule_interval', 7);
 
-            if ($cron === '') {
+            if ($scheduleInterval <= 0) {
                 return;
             }
 
             $schedule->command('lada-cache:calibrate', ['--apply'])
-                ->cron($cron)
+                ->dailyAt('03:00')
+                ->when(static fn (): bool => self::calibrationScheduleIntervalMatches($scheduleInterval))
                 ->onOneServer()
                 ->withoutOverlapping()
                 ->runInBackground();
@@ -216,33 +216,33 @@ final class LadaCacheServiceProvider extends ServiceProvider
     {
         $this->app->singleton('lada.redis', static fn () => new Redis);
 
-        $this->app->singleton('lada.cache', static fn (Application $app) => new Cache($app->make('lada.redis'), new Encoder)
+        $this->app->singleton('lada.cache', static fn (Application $app) => new Cache(self::resolveRedis($app), new Encoder)
         );
 
-        $this->app->singleton('lada.invalidator', static fn (Application $app) => new Invalidator($app->make('lada.redis'))
+        $this->app->singleton('lada.invalidator', static fn (Application $app) => new Invalidator(self::resolveRedis($app))
         );
 
         $this->app->singleton('lada.ttl_calibration_repo', static fn () => new TtlCalibrationRepository);
 
         $this->app->singleton('lada.ttl_resolver', static fn (Application $app) => new TtlResolver(
-            $app->make('lada.ttl_calibration_repo'),
+            self::resolveTtlCalibrationRepository($app),
         ));
 
         $this->app->singleton('lada.handler', static fn (Application $app) => new QueryHandler(
-            $app->make('lada.cache'),
-            $app->make('lada.invalidator'),
-            $app->make('lada.ttl_resolver'),
+            self::resolveCache($app),
+            self::resolveInvalidator($app),
+            self::resolveTtlResolver($app),
         ));
 
         $this->app->singleton('lada.stats_counter', static fn (Application $app) => new StatsCounter(
-            $app->make('lada.redis'),
-            (int) config('lada-cache.stats.flush_max_batch', 100),
-            (float) config('lada-cache.stats.flush_max_seconds', 5.0),
-            (int) config('lada-cache.stats.bucket_ttl_seconds', 86400 * 7),
+            self::resolveRedis($app),
+            Config::integer('lada-cache.calibration.activity_flush_max_batch', 100),
+            Config::float('lada-cache.calibration.activity_flush_max_seconds', 5.0),
+            Config::integer('lada-cache.calibration.activity_bucket_ttl_seconds', 86400 * 7),
         ));
 
         $this->app->singleton('lada.stats_reader', static fn (Application $app) => new StatsReader(
-            $app->make('lada.redis'),
+            self::resolveRedis($app),
         ));
     }
 
@@ -360,18 +360,10 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 return new CalibrateCommand;
             }
 
-            // StatsReader is optional — the command falls back to "idletime_only"
-            // when null. Only inject it when both events + stats are enabled, so
-            // disabled installs don't pay for an unused Redis connection.
-            $statsReader = ((bool) config('lada-cache.events.enabled', false)
-                && (bool) config('lada-cache.stats.enabled', false))
-                ? $app->make('lada.stats_reader')
-                : null;
-
             return new CalibrateCommand(
-                $app->make('lada.redis'),
-                $app->make('lada.ttl_calibration_repo'),
-                $statsReader,
+                self::resolveRedis($app),
+                self::resolveTtlCalibrationRepository($app),
+                self::resolveStatsReader($app),
             );
         });
 
@@ -387,5 +379,82 @@ final class LadaCacheServiceProvider extends ServiceProvider
     {
         $this->app->singleton('lada.collector', static fn () => new CacheCollector);
         $this->app->make('debugbar')->addCollector($this->app->make('lada.collector'));
+    }
+
+    private static function calibrationScheduleIntervalMatches(int $scheduleInterval, ?int $timestamp = null): bool
+    {
+        if ($scheduleInterval <= 1) {
+            return true;
+        }
+
+        $dayNumber = intdiv($timestamp ?? time(), 86400);
+
+        return $dayNumber % $scheduleInterval === 0;
+    }
+
+    private static function resolveRedis(Application $app): Redis
+    {
+        $redis = $app->make('lada.redis');
+
+        if (! $redis instanceof Redis) {
+            throw new \RuntimeException('Container binding lada.redis must resolve to '.Redis::class.'.');
+        }
+
+        return $redis;
+    }
+
+    private static function resolveTtlCalibrationRepository(Application $app): TtlCalibrationRepository
+    {
+        $repository = $app->make('lada.ttl_calibration_repo');
+
+        if (! $repository instanceof TtlCalibrationRepository) {
+            throw new \RuntimeException('Container binding lada.ttl_calibration_repo must resolve to '.TtlCalibrationRepository::class.'.');
+        }
+
+        return $repository;
+    }
+
+    private static function resolveCache(Application $app): Cache
+    {
+        $cache = $app->make('lada.cache');
+
+        if (! $cache instanceof Cache) {
+            throw new \RuntimeException('Container binding lada.cache must resolve to '.Cache::class.'.');
+        }
+
+        return $cache;
+    }
+
+    private static function resolveInvalidator(Application $app): Invalidator
+    {
+        $invalidator = $app->make('lada.invalidator');
+
+        if (! $invalidator instanceof Invalidator) {
+            throw new \RuntimeException('Container binding lada.invalidator must resolve to '.Invalidator::class.'.');
+        }
+
+        return $invalidator;
+    }
+
+    private static function resolveTtlResolver(Application $app): TtlResolver
+    {
+        $ttlResolver = $app->make('lada.ttl_resolver');
+
+        if (! $ttlResolver instanceof TtlResolver) {
+            throw new \RuntimeException('Container binding lada.ttl_resolver must resolve to '.TtlResolver::class.'.');
+        }
+
+        return $ttlResolver;
+    }
+
+    private static function resolveStatsReader(Application $app): StatsReader
+    {
+        $statsReader = $app->make('lada.stats_reader');
+
+        if (! $statsReader instanceof StatsReader) {
+            throw new \RuntimeException('Container binding lada.stats_reader must resolve to '.StatsReader::class.'.');
+        }
+
+        return $statsReader;
     }
 }

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -95,6 +95,7 @@ final class LadaCacheServiceProvider extends ServiceProvider
             'lada.redis',
             'lada.cache',
             'lada.invalidator',
+            'lada.ttl_resolver',
             'lada.handler',
         ];
     }
@@ -109,8 +110,13 @@ final class LadaCacheServiceProvider extends ServiceProvider
         $this->app->singleton('lada.invalidator', static fn (Application $app) => new Invalidator($app->make('lada.redis'))
         );
 
-        $this->app->singleton('lada.handler', static fn (Application $app) => new QueryHandler($app->make('lada.cache'), $app->make('lada.invalidator'))
-        );
+        $this->app->singleton('lada.ttl_resolver', static fn () => new TtlResolver);
+
+        $this->app->singleton('lada.handler', static fn (Application $app) => new QueryHandler(
+            $app->make('lada.cache'),
+            $app->make('lada.invalidator'),
+            $app->make('lada.ttl_resolver'),
+        ));
     }
 
     /**

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionRolledBack;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
+use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
+use Spiritix\LadaCache\Console\CalibrateCommand;
 use Spiritix\LadaCache\Console\DisableCommand;
 use Spiritix\LadaCache\Console\EnableCommand;
 use Spiritix\LadaCache\Console\FlushCommand;
@@ -36,6 +38,12 @@ final class LadaCacheServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../config/'.self::CONFIG_FILE => config_path(self::CONFIG_FILE),
         ], 'config');
+
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+
+        $this->publishesMigrations([
+            __DIR__.'/../database/migrations' => database_path('migrations'),
+        ], 'migrations');
 
         // If Lada Cache is not active, avoid wiring listeners / debugbar that could resolve Redis.
         if (! (bool) config('lada-cache.active', true)) {
@@ -95,6 +103,7 @@ final class LadaCacheServiceProvider extends ServiceProvider
             'lada.redis',
             'lada.cache',
             'lada.invalidator',
+            'lada.ttl_calibration_repo',
             'lada.ttl_resolver',
             'lada.handler',
         ];
@@ -110,7 +119,11 @@ final class LadaCacheServiceProvider extends ServiceProvider
         $this->app->singleton('lada.invalidator', static fn (Application $app) => new Invalidator($app->make('lada.redis'))
         );
 
-        $this->app->singleton('lada.ttl_resolver', static fn () => new TtlResolver);
+        $this->app->singleton('lada.ttl_calibration_repo', static fn () => new TtlCalibrationRepository);
+
+        $this->app->singleton('lada.ttl_resolver', static fn (Application $app) => new TtlResolver(
+            $app->make('lada.ttl_calibration_repo'),
+        ));
 
         $this->app->singleton('lada.handler', static fn (Application $app) => new QueryHandler(
             $app->make('lada.cache'),
@@ -213,10 +226,25 @@ final class LadaCacheServiceProvider extends ServiceProvider
         $this->app->singleton('command.lada-cache.enable', static fn () => new EnableCommand);
         $this->app->singleton('command.lada-cache.disable', static fn () => new DisableCommand);
 
+        // When Lada is disabled, lada.redis / lada.ttl_calibration_repo are not bound —
+        // instantiate the command without dependencies so its disabled-mode graceful path
+        // still runs (otherwise the container resolution would throw).
+        $this->app->singleton('command.lada-cache.calibrate', static function (Application $app): CalibrateCommand {
+            if (! (bool) config('lada-cache.active', true)) {
+                return new CalibrateCommand;
+            }
+
+            return new CalibrateCommand(
+                $app->make('lada.redis'),
+                $app->make('lada.ttl_calibration_repo'),
+            );
+        });
+
         $this->commands([
             'command.lada-cache.flush',
             'command.lada-cache.enable',
             'command.lada-cache.disable',
+            'command.lada-cache.calibrate',
         ]);
     }
 

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -16,6 +16,7 @@ use Illuminate\Database\SqliteConnection;
 use Illuminate\Database\SqlServerConnection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Octane\Events\RequestHandled;
 use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
 use Spiritix\LadaCache\Console\CalibrateCommand;
 use Spiritix\LadaCache\Console\DisableCommand;
@@ -94,8 +95,22 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 $counter->handle($event);
             });
 
-            // Final flush at app shutdown so the trailing batch isn't lost.
-            // Works under FPM (per-request), Octane (per-worker-shutdown), and CLI.
+            // Dual flush hook for the trailing batch:
+            //
+            //   - FPM / CLI:      Application::terminating() fires per-request /
+            //                     once before the worker exits. Per-request under
+            //                     FPM because each request rebuilds the kernel.
+            //   - Octane (Swoole/RoadRunner/FrankenPHP):
+            //                     Application::terminating() fires once at
+            //                     **worker shutdown**, NOT per-request. Without
+            //                     the RequestHandled listener below, the
+            //                     in-memory buffer could persist for minutes or
+            //                     hours and be lost on a worker crash / OOM /
+            //                     graceful restart. The Octane-specific event
+            //                     gives us a per-request boundary equivalent to
+            //                     the FPM lifecycle.
+            //
+            // Both listeners are idempotent: an empty buffer is a no-op.
             $this->app->terminating(static function (): void {
                 if (! app()->bound('lada.stats_counter')) {
                     return;
@@ -105,6 +120,21 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 $counter = app('lada.stats_counter');
                 $counter->flush();
             });
+
+            // Defensive class_exists() so the package doesn't require
+            // laravel/octane as a hard dependency — non-Octane apps simply skip
+            // the registration.
+            if (class_exists(RequestHandled::class)) {
+                $events->listen(RequestHandled::class, static function (): void {
+                    if (! app()->bound('lada.stats_counter')) {
+                        return;
+                    }
+
+                    /** @var StatsCounter $counter */
+                    $counter = app('lada.stats_counter');
+                    $counter->flush();
+                });
+            }
         }
 
         // Auto-register the calibration cron when enabled and a schedule expression is set.

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -6,9 +6,14 @@ namespace Spiritix\LadaCache;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Database\Connection;
 use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Database\Events\TransactionRolledBack;
+use Illuminate\Database\MySqlConnection;
+use Illuminate\Database\PostgresConnection;
+use Illuminate\Database\SqliteConnection;
+use Illuminate\Database\SqlServerConnection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
@@ -16,12 +21,15 @@ use Spiritix\LadaCache\Console\CalibrateCommand;
 use Spiritix\LadaCache\Console\DisableCommand;
 use Spiritix\LadaCache\Console\EnableCommand;
 use Spiritix\LadaCache\Console\FlushCommand;
-use Spiritix\LadaCache\Database\MySqlConnection as LadaMySqlConnection;
 use Spiritix\LadaCache\Database\MariaDbConnection as LadaMariaDbConnection;
+use Spiritix\LadaCache\Database\MySqlConnection as LadaMySqlConnection;
 use Spiritix\LadaCache\Database\PostgresConnection as LadaPostgresConnection;
 use Spiritix\LadaCache\Database\SqliteConnection as LadaSqliteConnection;
 use Spiritix\LadaCache\Database\SqlServerConnection as LadaSqlServerConnection;
 use Spiritix\LadaCache\Debug\CacheCollector;
+use Spiritix\LadaCache\Events\LadaCacheActivity;
+use Spiritix\LadaCache\Stats\StatsCounter;
+use Spiritix\LadaCache\Stats\StatsReader;
 
 /**
  * Lada Cache service provider for Laravel.
@@ -75,6 +83,30 @@ final class LadaCacheServiceProvider extends ServiceProvider
             $cache->flush();
         });
 
+        // Wire StatsCounter as a listener for LadaCacheActivity events when both
+        // event dispatch AND stats collection are enabled. The counter buffers
+        // in process memory and flushes either on threshold or at app shutdown.
+        if ((bool) config('lada-cache.events.enabled', false)
+            && (bool) config('lada-cache.stats.enabled', false)) {
+            $events->listen(LadaCacheActivity::class, static function (LadaCacheActivity $event): void {
+                /** @var StatsCounter $counter */
+                $counter = app('lada.stats_counter');
+                $counter->handle($event);
+            });
+
+            // Final flush at app shutdown so the trailing batch isn't lost.
+            // Works under FPM (per-request), Octane (per-worker-shutdown), and CLI.
+            $this->app->terminating(static function (): void {
+                if (! app()->bound('lada.stats_counter')) {
+                    return;
+                }
+
+                /** @var StatsCounter $counter */
+                $counter = app('lada.stats_counter');
+                $counter->flush();
+            });
+        }
+
         // Auto-register the calibration cron when enabled and a schedule expression is set.
         // Uses callAfterResolving so we don't force the Schedule kernel to boot unnecessarily —
         // it fires only when the framework itself resolves the scheduler (artisan schedule:* etc).
@@ -95,8 +127,7 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 ->cron($cron)
                 ->onOneServer()
                 ->withoutOverlapping()
-                ->runInBackground()
-            ;
+                ->runInBackground();
         });
     }
 
@@ -131,6 +162,8 @@ final class LadaCacheServiceProvider extends ServiceProvider
             'lada.ttl_calibration_repo',
             'lada.ttl_resolver',
             'lada.handler',
+            'lada.stats_counter',
+            'lada.stats_reader',
         ];
     }
 
@@ -155,12 +188,23 @@ final class LadaCacheServiceProvider extends ServiceProvider
             $app->make('lada.invalidator'),
             $app->make('lada.ttl_resolver'),
         ));
+
+        $this->app->singleton('lada.stats_counter', static fn (Application $app) => new StatsCounter(
+            $app->make('lada.redis'),
+            (int) config('lada-cache.stats.flush_max_batch', 100),
+            (float) config('lada-cache.stats.flush_max_seconds', 5.0),
+            (int) config('lada-cache.stats.bucket_ttl_seconds', 86400 * 7),
+        ));
+
+        $this->app->singleton('lada.stats_reader', static fn (Application $app) => new StatsReader(
+            $app->make('lada.redis'),
+        ));
     }
 
     /**
      * Copy driver-specific state from the base connection to the Lada connection.
      */
-    private function hydrateLadaConnection(\Illuminate\Database\Connection $base, \Illuminate\Database\Connection $lada, string $name): \Illuminate\Database\Connection
+    private function hydrateLadaConnection(Connection $base, Connection $lada, string $name): Connection
     {
         if (method_exists($lada, 'setReadPdo')) {
             $lada->setReadPdo($base->getReadPdo());
@@ -183,8 +227,8 @@ final class LadaCacheServiceProvider extends ServiceProvider
 
     private function registerDatabaseDecorator(): void
     {
-        DB::extend('mysql', function (array $config, string $name): \Illuminate\Database\Connection {
-            /** @var \Illuminate\Database\MySqlConnection $base */
+        DB::extend('mysql', function (array $config, string $name): Connection {
+            /** @var MySqlConnection $base */
             $base = app('db.factory')->make($config, $name);
             $lada = new LadaMySqlConnection(
                 $base->getPdo(),
@@ -192,12 +236,13 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 $base->getTablePrefix(),
                 $base->getConfig(),
             );
+
             return $this->hydrateLadaConnection($base, $lada, $name);
         });
 
         // Optional explicit MariaDB driver (alias of MySQL)
-        DB::extend('mariadb', function (array $config, string $name): \Illuminate\Database\Connection {
-            /** @var \Illuminate\Database\MySqlConnection $base */
+        DB::extend('mariadb', function (array $config, string $name): Connection {
+            /** @var MySqlConnection $base */
             $base = app('db.factory')->make($config, $name);
             $lada = new LadaMariaDbConnection(
                 $base->getPdo(),
@@ -205,11 +250,12 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 $base->getTablePrefix(),
                 $base->getConfig(),
             );
+
             return $this->hydrateLadaConnection($base, $lada, $name);
         });
 
-        DB::extend('pgsql', function (array $config, string $name): \Illuminate\Database\Connection {
-            /** @var \Illuminate\Database\PostgresConnection $base */
+        DB::extend('pgsql', function (array $config, string $name): Connection {
+            /** @var PostgresConnection $base */
             $base = app('db.factory')->make($config, $name);
             $lada = new LadaPostgresConnection(
                 $base->getPdo(),
@@ -217,11 +263,12 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 $base->getTablePrefix(),
                 $base->getConfig(),
             );
+
             return $this->hydrateLadaConnection($base, $lada, $name);
         });
 
-        DB::extend('sqlite', function (array $config, string $name): \Illuminate\Database\Connection {
-            /** @var \Illuminate\Database\SqliteConnection $base */
+        DB::extend('sqlite', function (array $config, string $name): Connection {
+            /** @var SqliteConnection $base */
             $base = app('db.factory')->make($config, $name);
             $lada = new LadaSqliteConnection(
                 $base->getPdo(),
@@ -229,11 +276,12 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 $base->getTablePrefix(),
                 $base->getConfig(),
             );
+
             return $this->hydrateLadaConnection($base, $lada, $name);
         });
 
-        DB::extend('sqlsrv', function (array $config, string $name): \Illuminate\Database\Connection {
-            /** @var \Illuminate\Database\SqlServerConnection $base */
+        DB::extend('sqlsrv', function (array $config, string $name): Connection {
+            /** @var SqlServerConnection $base */
             $base = app('db.factory')->make($config, $name);
             $lada = new LadaSqlServerConnection(
                 $base->getPdo(),
@@ -241,6 +289,7 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 $base->getTablePrefix(),
                 $base->getConfig(),
             );
+
             return $this->hydrateLadaConnection($base, $lada, $name);
         });
     }
@@ -266,9 +315,18 @@ final class LadaCacheServiceProvider extends ServiceProvider
                 return new CalibrateCommand;
             }
 
+            // StatsReader is optional — the command falls back to "idletime_only"
+            // when null. Only inject it when both events + stats are enabled, so
+            // disabled installs don't pay for an unused Redis connection.
+            $statsReader = ((bool) config('lada-cache.events.enabled', false)
+                && (bool) config('lada-cache.stats.enabled', false))
+                ? $app->make('lada.stats_reader')
+                : null;
+
             return new CalibrateCommand(
                 $app->make('lada.redis'),
                 $app->make('lada.ttl_calibration_repo'),
+                $statsReader,
             );
         });
 

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiritix\LadaCache;
 
+use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Database\Events\TransactionCommitted;
@@ -72,6 +73,30 @@ final class LadaCacheServiceProvider extends ServiceProvider
             /** @var Cache $cache */
             $cache = $this->app->make('lada.cache');
             $cache->flush();
+        });
+
+        // Auto-register the calibration cron when enabled and a schedule expression is set.
+        // Uses callAfterResolving so we don't force the Schedule kernel to boot unnecessarily —
+        // it fires only when the framework itself resolves the scheduler (artisan schedule:* etc).
+        // To opt out, set config('lada-cache.calibration.schedule') to an empty string and call
+        // Schedule::command(...) yourself in routes/console.php instead.
+        $this->callAfterResolving(Schedule::class, function (Schedule $schedule): void {
+            if (! (bool) config('lada-cache.calibration.enabled', false)) {
+                return;
+            }
+
+            $cron = trim((string) config('lada-cache.calibration.schedule', ''));
+
+            if ($cron === '') {
+                return;
+            }
+
+            $schedule->command('lada-cache:calibrate', ['--apply'])
+                ->cron($cron)
+                ->onOneServer()
+                ->withoutOverlapping()
+                ->runInBackground()
+            ;
         });
     }
 

--- a/src/LadaCacheServiceProvider.php
+++ b/src/LadaCacheServiceProvider.php
@@ -254,8 +254,15 @@ final class LadaCacheServiceProvider extends ServiceProvider
         // When Lada is disabled, lada.redis / lada.ttl_calibration_repo are not bound —
         // instantiate the command without dependencies so its disabled-mode graceful path
         // still runs (otherwise the container resolution would throw).
+        //
+        // Also gate on `calibration.enabled`: `$this->commands()` triggers Artisan
+        // resolveCommands → container resolution, which fires during
+        // `package:discover` too. In Docker build / CI contexts without a Redis
+        // connection (the common case, since calibration.enabled defaults to false),
+        // resolving `lada.redis` here would fail with "Connection refused" and crash
+        // the build. Calibration disabled = no Redis touch; handle() exits early.
         $this->app->singleton('command.lada-cache.calibrate', static function (Application $app): CalibrateCommand {
-            if (! (bool) config('lada-cache.active', true)) {
+            if (! (bool) config('lada-cache.active', true) || ! (bool) config('lada-cache.calibration.enabled', false)) {
                 return new CalibrateCommand;
             }
 

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -34,19 +34,18 @@ final class QueryHandler
     private array $queuedInvalidations = [];
 
     /**
-     * Cached `lada-cache.events.enabled` flag. Resolved once at construction
-     * (QueryHandler is a singleton, so this happens once per worker) instead
-     * of paying for `config()` lookups on every cache hit / miss / invalidate
-     * — the hot path that touches every cached query.
+     * Cached calibration flag. Resolved once at construction (QueryHandler is
+     * a singleton, so this happens once per worker) instead of paying for
+     * `config()` lookups on every cache hit / miss / invalidate.
      */
-    private readonly bool $eventsEnabled;
+    private readonly bool $calibrationEnabled;
 
     public function __construct(
         private readonly Cache $cache,
         private readonly Invalidator $invalidator,
         private readonly TtlResolver $ttlResolver,
     ) {
-        $this->eventsEnabled = (bool) config('lada-cache.events.enabled', false);
+        $this->calibrationEnabled = (bool) config('lada-cache.calibration.enabled', false);
     }
 
     public function setBuilder(QueryBuilder $builder): self
@@ -253,8 +252,7 @@ final class QueryHandler
     /**
      * Dispatch a {@see LadaCacheActivity} event for the given action.
      *
-     * Opt-in via `lada-cache.events.enabled` to keep hot-path overhead zero
-     * by default. The flag is captured into `$this->eventsEnabled` at
+     * Enabled only while calibration is enabled. The flag is captured at
      * construction so this check is a single bool comparison rather than a
      * `config()` lookup per cache operation.
      *
@@ -265,7 +263,7 @@ final class QueryHandler
      */
     private function dispatchActivity(string $action, string $key, array $tags, Reflector $reflector): void
     {
-        if (! $this->eventsEnabled) {
+        if (! $this->calibrationEnabled) {
             return;
         }
 

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -33,11 +33,21 @@ final class QueryHandler
     /** @var array<string, array<int, string>> */
     private array $queuedInvalidations = [];
 
+    /**
+     * Cached `lada-cache.events.enabled` flag. Resolved once at construction
+     * (QueryHandler is a singleton, so this happens once per worker) instead
+     * of paying for `config()` lookups on every cache hit / miss / invalidate
+     * — the hot path that touches every cached query.
+     */
+    private readonly bool $eventsEnabled;
+
     public function __construct(
         private readonly Cache $cache,
         private readonly Invalidator $invalidator,
         private readonly TtlResolver $ttlResolver,
-    ) {}
+    ) {
+        $this->eventsEnabled = (bool) config('lada-cache.events.enabled', false);
+    }
 
     public function setBuilder(QueryBuilder $builder): self
     {
@@ -244,14 +254,18 @@ final class QueryHandler
      * Dispatch a {@see LadaCacheActivity} event for the given action.
      *
      * Opt-in via `lada-cache.events.enabled` to keep hot-path overhead zero
-     * by default. The dispatch is wrapped in try/catch so a misbehaving
-     * listener cannot break the query path (cache read or invalidation).
+     * by default. The flag is captured into `$this->eventsEnabled` at
+     * construction so this check is a single bool comparison rather than a
+     * `config()` lookup per cache operation.
+     *
+     * The dispatch is wrapped in try/catch so a misbehaving listener cannot
+     * break the query path (cache read or invalidation).
      *
      * @param  array<string>  $tags
      */
     private function dispatchActivity(string $action, string $key, array $tags, Reflector $reflector): void
     {
-        if (! config('lada-cache.events.enabled', false)) {
+        if (! $this->eventsEnabled) {
             return;
         }
 

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -35,6 +35,7 @@ final class QueryHandler
     public function __construct(
         private readonly Cache $cache,
         private readonly Invalidator $invalidator,
+        private readonly TtlResolver $ttlResolver,
     ) {}
 
     public function setBuilder(QueryBuilder $builder): self
@@ -156,7 +157,8 @@ final class QueryHandler
 
             if ($cached === null) {
                 $cached = $queryClosure();
-                $this->cache->set($key, $tags, $cached);
+                $ttl = $this->ttlResolver->resolve($this->builder->getModel());
+                $this->cache->set($key, $tags, $cached, $ttl);
             } else {
                 // Self-heal tag membership inconsistencies by idempotently adding the key to each tag set.
                 $this->cache->repairTagMembership($key, $tags);

--- a/src/QueryHandler.php
+++ b/src/QueryHandler.php
@@ -9,6 +9,7 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Facades\App;
 use Spiritix\LadaCache\Database\QueryBuilder;
 use Spiritix\LadaCache\Debug\CacheCollector;
+use Spiritix\LadaCache\Events\LadaCacheActivity;
 use Throwable;
 
 /**
@@ -106,12 +107,14 @@ final class QueryHandler
 
                 // We can't know hashes before flushing; record action only.
                 $this->stopCollector($reflector, $tags, [], "Invalidation queued ({$statementType})");
+                $this->dispatchActivity('invalidate', '', $tags, $reflector);
 
                 return;
             }
 
             $hashes = $this->invalidator->invalidate($tags);
             $this->stopCollector($reflector, $tags, $hashes, "Invalidation ({$statementType})");
+            $this->dispatchActivity('invalidate', '', $tags, $reflector);
         } catch (Throwable) {
             // On any reflection/type/tagging error during invalidation, skip invalidation silently.
             try {
@@ -163,6 +166,9 @@ final class QueryHandler
                 // Self-heal tag membership inconsistencies by idempotently adding the key to each tag set.
                 $this->cache->repairTagMembership($key, $tags);
             }
+
+            // Monitoring hook — opt-in via config to keep hot-path overhead zero by default.
+            $this->dispatchActivity($action === 'Hit' ? 'hit' : 'miss', $key, $tags, $reflector);
 
             $this->stopCollector($reflector, $tags, $key, $action);
 
@@ -232,5 +238,35 @@ final class QueryHandler
             $reflector->getSql(),
             $reflector->getParameters()
         );
+    }
+
+    /**
+     * Dispatch a {@see LadaCacheActivity} event for the given action.
+     *
+     * Opt-in via `lada-cache.events.enabled` to keep hot-path overhead zero
+     * by default. The dispatch is wrapped in try/catch so a misbehaving
+     * listener cannot break the query path (cache read or invalidation).
+     *
+     * @param  array<string>  $tags
+     */
+    private function dispatchActivity(string $action, string $key, array $tags, Reflector $reflector): void
+    {
+        if (! config('lada-cache.events.enabled', false)) {
+            return;
+        }
+
+        try {
+            $tables = $reflector->getTables();
+            $table = $tables[0] ?? null;
+
+            event(new LadaCacheActivity(
+                action: $action,
+                key: $key,
+                tags: $tags,
+                table: $table,
+            ));
+        } catch (Throwable $e) {
+            report($e);
+        }
     }
 }

--- a/src/Redis.php
+++ b/src/Redis.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Spiritix\LadaCache;
 
+use Generator;
 use Illuminate\Redis\Connections\Connection;
 use Illuminate\Support\Facades\Redis as RedisFacade;
 
@@ -50,5 +51,95 @@ final readonly class Redis
     public function getConnection(): Connection
     {
         return $this->connection;
+    }
+
+    /**
+     * Iterate Redis keys matching a glob pattern in cursor-driven batches.
+     *
+     * Wraps both PhpRedis (`scan`) and Predis (`scan`) cursor APIs in a single
+     * Generator interface so callers don't need to branch on the client type.
+     * Yields one batch (array of keys) per Redis round-trip. Non-blocking —
+     * safe to run against production with millions of keys.
+     *
+     * @return Generator<int, array<int, string>, mixed, void>
+     */
+    public function scanKeys(string $pattern, int $count = 1000): Generator
+    {
+        $client = $this->connection->client();
+
+        // PhpRedis native client
+        if ($client instanceof \Redis) {
+            $cursor = null;
+
+            do {
+                $keys = $client->scan($cursor, $pattern, $count);
+
+                if ($keys !== false && $keys !== []) {
+                    yield $keys;
+                }
+            } while ($cursor !== 0);
+
+            return;
+        }
+
+        // Predis client (object guard satisfies PHPStan when client() typehint is mixed)
+        if (is_object($client) && method_exists($client, 'scan')) {
+            $cursor = '0';
+
+            do {
+                $result = $client->scan($cursor, ['MATCH' => $pattern, 'COUNT' => $count]);
+                $cursor = (string) $result[0];
+                $keys = $result[1] ?? [];
+
+                if ($keys !== []) {
+                    yield $keys;
+                }
+            } while ($cursor !== '0');
+        }
+    }
+
+    /**
+     * Iterate members of a Redis SET in cursor-driven batches via SSCAN.
+     *
+     * Preferred over SMEMBERS for large tag sets because:
+     *   1. SMEMBERS is O(N) and blocks Redis for the duration.
+     *   2. The response can balloon client memory for million-member sets.
+     * Yields one batch (array of members) per Redis round-trip.
+     *
+     * @return Generator<int, array<int, string>, mixed, void>
+     */
+    public function sScanMembers(string $key, int $count = 1000): Generator
+    {
+        $client = $this->connection->client();
+
+        // PhpRedis native client
+        if ($client instanceof \Redis) {
+            $cursor = null;
+
+            do {
+                $members = $client->sScan($key, $cursor, '*', $count);
+
+                if ($members !== false && $members !== []) {
+                    yield $members;
+                }
+            } while ($cursor !== 0);
+
+            return;
+        }
+
+        // Predis client
+        if (is_object($client) && method_exists($client, 'sscan')) {
+            $cursor = '0';
+
+            do {
+                $result = $client->sscan($key, $cursor, ['MATCH' => '*', 'COUNT' => $count]);
+                $cursor = (string) $result[0];
+                $members = $result[1] ?? [];
+
+                if ($members !== []) {
+                    yield $members;
+                }
+            } while ($cursor !== '0');
+        }
     }
 }

--- a/src/Redis.php
+++ b/src/Redis.php
@@ -82,8 +82,10 @@ final readonly class Redis
             return;
         }
 
-        // Predis client (object guard satisfies PHPStan when client() typehint is mixed)
-        if (is_object($client) && method_exists($client, 'scan')) {
+        // Predis client (object guard satisfies PHPStan when client() typehint is mixed).
+        // Predis\Client exposes `scan` via __call magic, so method_exists() returns false —
+        // is_callable() honors __call and correctly probes Predis (and any compatible client).
+        if (is_object($client) && is_callable([$client, 'scan'])) {
             $cursor = '0';
 
             do {
@@ -127,8 +129,9 @@ final readonly class Redis
             return;
         }
 
-        // Predis client
-        if (is_object($client) && method_exists($client, 'sscan')) {
+        // Predis client — sscan is exposed via Predis\Client::__call, so use is_callable()
+        // (not method_exists, which returns false for magic methods).
+        if (is_object($client) && is_callable([$client, 'sscan'])) {
             $cursor = '0';
 
             do {

--- a/src/Redis.php
+++ b/src/Redis.php
@@ -20,6 +20,23 @@ use Illuminate\Support\Facades\Redis as RedisFacade;
  * - Keys should be prefixed using `prefix()` before being written to Redis to avoid
  *   collisions with application keys.
  * - The class is marked `readonly` as its state is fully defined at construction.
+ *
+ * The `@method` declarations below expose forwarded Redis commands to static
+ * analyzers (PHPStan/Larastan). PHP runtime dispatch is unaffected.
+ *
+ * @method mixed set(string $key, mixed $value, mixed ...$options)
+ * @method string|null get(string $key)
+ * @method int sadd(string $key, mixed ...$members)
+ * @method int srem(string $key, mixed ...$members)
+ * @method int sismember(string $key, mixed $member)
+ * @method array<int, string> smembers(string $key)
+ * @method array<int, string> keys(string $pattern)
+ * @method int del(string ...$keys)
+ * @method int unlink(string ...$keys)
+ * @method int exists(string ...$keys)
+ * @method mixed multi(?callable $callback = null)
+ * @method array<int, mixed> exec()
+ * @method array<int, mixed> pipeline(?callable $callback = null)
  */
 final readonly class Redis
 {

--- a/src/Stats/StatsCounter.php
+++ b/src/Stats/StatsCounter.php
@@ -36,7 +36,13 @@ use Throwable;
  *
  * Failure mode: a flush exception is caught and the pending counters are
  * restored so the next flush retries the lost batch. Telemetry must never
- * break a request.
+ * break a request. A sustained outage is bounded by `$maxPendingSize` —
+ * the oldest entries are dropped (with an error log) before the buffer
+ * can OOM the worker.
+ *
+ * Note: this class is intentionally NOT marked `readonly` at the class level
+ * because the `$pending` buffer is mutated on every event. Constructor
+ * parameters remain individually `readonly`.
  */
 final class StatsCounter
 {
@@ -50,6 +56,11 @@ final class StatsCounter
         private readonly int $maxBatchSize = 100,
         private readonly float $maxIntervalSeconds = 5.0,
         private readonly int $bucketTtlSeconds = 86400 * 7,
+        // Hard cap on `$pending` size. If Redis is unreachable for long enough
+        // that the restore-on-failure path keeps growing the buffer, oldest
+        // entries are dropped and an error is logged. Without this guard a
+        // stuck flush path could OOM the worker under heavy hit/miss traffic.
+        private readonly int $maxPendingSize = 10000,
     ) {
         $this->lastFlush = microtime(true);
     }
@@ -81,6 +92,8 @@ final class StatsCounter
 
         try {
             $bucket = $this->bucketKey();
+            // TTL is captured at construction time and re-passed into the
+            // pipeline closure to avoid re-reading config in the hot path.
             $ttl = $this->bucketTtlSeconds;
 
             $this->redis->pipeline(static function ($pipe) use ($bucket, $batch, $ttl): void {
@@ -96,7 +109,37 @@ final class StatsCounter
             foreach ($batch as $field => $count) {
                 $this->pending[$field] = ($this->pending[$field] ?? 0) + $count;
             }
+
+            $this->enforceMaxPendingSize();
         }
+    }
+
+    /**
+     * Drop the oldest entries from `$pending` if the buffer is over the
+     * configured cap after a failed flush restored its batch. Without this
+     * a sustained Redis outage would OOM the worker on a high-traffic site.
+     */
+    private function enforceMaxPendingSize(): void
+    {
+        if ($this->maxPendingSize <= 0) {
+            return;
+        }
+
+        $excess = count($this->pending) - $this->maxPendingSize;
+
+        if ($excess <= 0) {
+            return;
+        }
+
+        // PHP arrays preserve insertion order, so slicing from the start drops
+        // the oldest (table:action) keys first.
+        $this->pending = array_slice($this->pending, $excess, null, true);
+
+        Log::error(sprintf(
+            '[LadaCache] StatsCounter overflow — dropped %d entries (cap=%d). Redis flush is failing; investigate.',
+            $excess,
+            $this->maxPendingSize,
+        ));
     }
 
     /**
@@ -114,6 +157,13 @@ final class StatsCounter
         // Apply Lada's configured prefix so the bucket sits alongside other
         // Lada-owned Redis keys (and tests asserting against the expected key
         // via Redis::prefix() can find it).
-        return $this->redis->prefix('lada:stats:'.date('YmdH'));
+        //
+        // UTC bucket key (`gmdate`) — server timezone drift would otherwise
+        // produce different bucket names on writer and reader if they happen
+        // to run with different `date.timezone` settings (e.g. two workers
+        // started in different containers, or scheduler running on a host
+        // with a non-UTC clock). StatsReader uses the same `gmdate('YmdH')`
+        // format for symmetry.
+        return $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
     }
 }

--- a/src/Stats/StatsCounter.php
+++ b/src/Stats/StatsCounter.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Stats;
+
+use Illuminate\Support\Facades\Log;
+use Spiritix\LadaCache\Events\LadaCacheActivity;
+use Spiritix\LadaCache\Redis;
+use Throwable;
+
+/**
+ * Per-table cache activity counter (hit / miss / invalidate).
+ *
+ * Aggregates {@see LadaCacheActivity} events in process memory and periodically
+ * flushes the aggregate to Redis as HASH counters keyed by hour bucket:
+ *
+ *   lada:stats:YYYYMMDDHH
+ *     field "users:hit"        → 42819
+ *     field "users:miss"       → 512
+ *     field "users:invalidate" → 120
+ *     field "orders:hit"       → 2840
+ *     ...
+ *
+ * The hash is given a configurable TTL so older buckets self-evict.
+ *
+ * Flush is triggered by whichever condition fires first:
+ *   1. Pending distinct (table:action) keys exceed `maxBatchSize`.
+ *   2. Time since last flush exceeds `maxIntervalSeconds`.
+ *   3. The application terminates (via `Application::terminating()` hook
+ *      registered by the service provider).
+ *
+ * Runtime-agnostic: works under Octane (singleton state persists across
+ * requests), FPM (per-request lifecycle), queue workers, and the scheduler.
+ * No dependency on Octane-specific timers.
+ *
+ * Failure mode: a flush exception is caught and the pending counters are
+ * restored so the next flush retries the lost batch. Telemetry must never
+ * break a request.
+ */
+final class StatsCounter
+{
+    /** @var array<string, int> table:action => count */
+    private array $pending = [];
+
+    private float $lastFlush;
+
+    public function __construct(
+        private readonly Redis $redis,
+        private readonly int $maxBatchSize = 100,
+        private readonly float $maxIntervalSeconds = 5.0,
+        private readonly int $bucketTtlSeconds = 86400 * 7,
+    ) {
+        $this->lastFlush = microtime(true);
+    }
+
+    public function handle(LadaCacheActivity $event): void
+    {
+        $table = $event->table ?? 'unknown';
+        $field = $table.':'.$event->action;
+
+        $this->pending[$field] = ($this->pending[$field] ?? 0) + 1;
+
+        if (count($this->pending) >= $this->maxBatchSize
+            || (microtime(true) - $this->lastFlush) >= $this->maxIntervalSeconds) {
+            $this->flush();
+        }
+    }
+
+    public function flush(): void
+    {
+        if ($this->pending === []) {
+            $this->lastFlush = microtime(true);
+
+            return;
+        }
+
+        $batch = $this->pending;
+        $this->pending = [];
+        $this->lastFlush = microtime(true);
+
+        try {
+            $bucket = $this->bucketKey();
+            $ttl = $this->bucketTtlSeconds;
+
+            $this->redis->pipeline(static function ($pipe) use ($bucket, $batch, $ttl): void {
+                foreach ($batch as $field => $count) {
+                    $pipe->hincrby($bucket, $field, $count);
+                }
+                $pipe->expire($bucket, $ttl);
+            });
+        } catch (Throwable $e) {
+            Log::warning('[LadaCache] Stats flush failed: '.$e->getMessage());
+
+            // Restore so the next flush retries the lost batch.
+            foreach ($batch as $field => $count) {
+                $this->pending[$field] = ($this->pending[$field] ?? 0) + $count;
+            }
+        }
+    }
+
+    /**
+     * Return pending counters without flushing — primarily for tests/diagnostics.
+     *
+     * @return array<string, int>
+     */
+    public function pending(): array
+    {
+        return $this->pending;
+    }
+
+    private function bucketKey(): string
+    {
+        // Apply Lada's configured prefix so the bucket sits alongside other
+        // Lada-owned Redis keys (and tests asserting against the expected key
+        // via Redis::prefix() can find it).
+        return $this->redis->prefix('lada:stats:'.date('YmdH'));
+    }
+}

--- a/src/Stats/StatsReader.php
+++ b/src/Stats/StatsReader.php
@@ -41,8 +41,12 @@ final readonly class StatsReader
      * Action labels emitted by {@see QueryHandler::dispatchActivity()}.
      * Kept in sync with that call site so unrecognized fields are ignored
      * rather than silently summed into a bucket they don't belong to.
+     *
+     * Note: no `array` type on the constant — typed class constants require
+     * PHP 8.3+ and we want to keep the package compatible with older runtimes
+     * that still satisfy `^8.1` in downstream apps consuming this package.
      */
-    private const array DEFAULT_ACTIONS = ['hit', 'miss', 'invalidate'];
+    private const DEFAULT_ACTIONS = ['hit', 'miss', 'invalidate'];
 
     public function __construct(
         private Redis $redis,

--- a/src/Stats/StatsReader.php
+++ b/src/Stats/StatsReader.php
@@ -111,6 +111,10 @@ final readonly class StatsReader
      * Prefixed bucket keys covering the lookback window. Inclusive of the
      * current hour bucket (where in-flight events still accumulate).
      *
+     * UTC bucket key (`gmdate`) — must match the writer's format in
+     * {@see StatsCounter::bucketKey()} so we don't
+     * miss buckets when writer / reader run in different server timezones.
+     *
      * @return string[]
      */
     private function bucketKeysForLookback(int $hoursBack): array
@@ -119,7 +123,7 @@ final readonly class StatsReader
         $keys = [];
 
         for ($i = 0; $i < $hoursBack; $i++) {
-            $hour = date('YmdH', $now - ($i * 3600));
+            $hour = gmdate('YmdH', $now - ($i * 3600));
             $keys[] = $this->redis->prefix('lada:stats:'.$hour);
         }
 

--- a/src/Stats/StatsReader.php
+++ b/src/Stats/StatsReader.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Stats;
+
+use Spiritix\LadaCache\QueryHandler;
+use Spiritix\LadaCache\Redis;
+
+/**
+ * Reads StatsCounter-produced `lada:stats:*` hourly HASH buckets and aggregates
+ * activity counts per (table, action) across a recent time window.
+ *
+ * Used by {@see \Spiritix\LadaCache\Console\CalibrateCommand} to enrich the
+ * OBJECT IDLETIME signal with read / write frequency before computing a
+ * per-model TTL.
+ *
+ * Returned shape per table:
+ *   [
+ *     'hit'        => int,  // cache HIT count
+ *     'miss'       => int,  // cache MISS count (DB query executed)
+ *     'invalidate' => int,  // tag/key invalidation count (writes to that table)
+ *   ]
+ *
+ * Bucket key format: `lada:stats:YYYYMMDDHH` (the same wall-clock format
+ * StatsCounter uses on write). Missing buckets contribute 0 — pipelined
+ * HGETALL returns an empty array for non-existent keys, which is benign.
+ *
+ * Failure semantics: Redis/pipeline exceptions are NOT swallowed here. The
+ * caller ({@see CalibrateCommand::loadActivity()}) is responsible for catching
+ * them so it can distinguish a real Redis failure ("idletime_only" fallback)
+ * from a genuinely empty bucket window ("no_activity"). Swallowing at this
+ * layer would collapse both into a misleading no_activity classification and
+ * hide operational issues from the cron summary log + monitoring.
+ *
+ * Octane-safe: no mutable instance state beyond the constructor dependency.
+ */
+final readonly class StatsReader
+{
+    /**
+     * Action labels emitted by {@see QueryHandler::dispatchActivity()}.
+     * Kept in sync with that call site so unrecognized fields are ignored
+     * rather than silently summed into a bucket they don't belong to.
+     */
+    private const array DEFAULT_ACTIONS = ['hit', 'miss', 'invalidate'];
+
+    public function __construct(
+        private Redis $redis,
+    ) {}
+
+    /**
+     * Aggregate activity over the last $hoursBack hours, keyed by table.
+     *
+     * Reads all bucket keys in a single Redis pipeline round-trip. Redis or
+     * pipeline failures are intentionally **not** caught here; see the class
+     * PHPDoc for the rationale. A non-array pipeline reply (driver oddity) is
+     * tolerated and returns empty.
+     *
+     * @return array<string, array{hit:int, miss:int, invalidate:int}>
+     */
+    public function readAllActivity(int $hoursBack): array
+    {
+        if ($hoursBack <= 0) {
+            return [];
+        }
+
+        $buckets = $this->bucketKeysForLookback($hoursBack);
+
+        $results = $this->redis->pipeline(static function ($pipe) use ($buckets): void {
+            foreach ($buckets as $bucket) {
+                $pipe->hgetall($bucket);
+            }
+        });
+
+        if (! is_array($results)) {
+            return [];
+        }
+
+        $aggregate = [];
+
+        foreach ($results as $hash) {
+            if (! is_array($hash) || $hash === []) {
+                continue;
+            }
+
+            foreach ($hash as $field => $count) {
+                $parts = explode(':', (string) $field, 2);
+
+                if (count($parts) !== 2) {
+                    continue;
+                }
+
+                [$table, $action] = $parts;
+
+                if (! in_array($action, self::DEFAULT_ACTIONS, true)) {
+                    continue;
+                }
+
+                if (! isset($aggregate[$table])) {
+                    $aggregate[$table] = ['hit' => 0, 'miss' => 0, 'invalidate' => 0];
+                }
+
+                $aggregate[$table][$action] += (int) $count;
+            }
+        }
+
+        return $aggregate;
+    }
+
+    /**
+     * Prefixed bucket keys covering the lookback window. Inclusive of the
+     * current hour bucket (where in-flight events still accumulate).
+     *
+     * @return string[]
+     */
+    private function bucketKeysForLookback(int $hoursBack): array
+    {
+        $now = time();
+        $keys = [];
+
+        for ($i = 0; $i < $hoursBack; $i++) {
+            $hour = date('YmdH', $now - ($i * 3600));
+            $keys[] = $this->redis->prefix('lada:stats:'.$hour);
+        }
+
+        return $keys;
+    }
+}

--- a/src/TtlResolver.php
+++ b/src/TtlResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache;
+
+use Illuminate\Database\Eloquent\Model;
+use Spiritix\LadaCache\Contracts\HasLadaTtl;
+
+/**
+ * Resolves the effective Lada Cache TTL for a given Eloquent model.
+ *
+ * Resolution order (first non-null wins):
+ *   1. Model implements HasLadaTtl → $model->getLadaTtl()
+ *   2. config('lada-cache.model_ttls.<FQCN>')
+ *   3. null → caller defers to global config('lada-cache.expiration_time')
+ *
+ * Octane-safe: no mutable state, config is read once at construction.
+ */
+final class TtlResolver
+{
+    /** @var array<class-string, ?int> */
+    private readonly array $modelTtls;
+
+    public function __construct()
+    {
+        /** @var array<class-string, ?int> $configured */
+        $configured = (array) config('lada-cache.model_ttls', []);
+        $this->modelTtls = $configured;
+    }
+
+    public function resolve(?Model $model): ?int
+    {
+        if ($model === null) {
+            return null;
+        }
+
+        if ($model instanceof HasLadaTtl) {
+            $ttl = $model->getLadaTtl();
+
+            if ($ttl !== null) {
+                return $ttl;
+            }
+        }
+
+        return $this->modelTtls[$model::class] ?? null;
+    }
+}

--- a/src/TtlResolver.php
+++ b/src/TtlResolver.php
@@ -5,25 +5,35 @@ declare(strict_types=1);
 namespace Spiritix\LadaCache;
 
 use Illuminate\Database\Eloquent\Model;
+use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
 use Spiritix\LadaCache\Contracts\HasLadaTtl;
+use Throwable;
 
 /**
  * Resolves the effective Lada Cache TTL for a given Eloquent model.
  *
  * Resolution order (first non-null wins):
  *   1. Model implements HasLadaTtl → $model->getLadaTtl()
- *   2. config('lada-cache.model_ttls.<FQCN>')
- *   3. null → caller defers to global config('lada-cache.expiration_time')
+ *   2. lada_cache_calibrations.calibrated_ttl (auto-calibration via lada-cache:calibrate)
+ *   3. config('lada-cache.model_ttls.<FQCN>')
+ *   4. null → caller defers to global config('lada-cache.expiration_time')
  *
- * Octane-safe: no mutable state, config is read once at construction.
+ * Octane-safe: no mutable state, modelTtls read once at boot. Calibration
+ * lookups go through TtlCalibrationRepository which caches the DB map in-memory
+ * (Cache::remember) for `lada-cache.calibration.cache_ttl` seconds.
+ *
+ * Calibration repo is optional — if not bound or DB unavailable, resolver
+ * gracefully skips layer 2 and falls through to config/global. This keeps
+ * boot-time decoupled from DB availability.
  */
 final class TtlResolver
 {
     /** @var array<class-string, ?int> */
     private readonly array $modelTtls;
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly ?TtlCalibrationRepository $calibrations = null,
+    ) {
         /** @var array<class-string, ?int> $configured */
         $configured = (array) config('lada-cache.model_ttls', []);
         $this->modelTtls = $configured;
@@ -40,6 +50,18 @@ final class TtlResolver
 
             if ($ttl !== null) {
                 return $ttl;
+            }
+        }
+
+        if ($this->calibrations !== null && (bool) config('lada-cache.calibration.enabled', false)) {
+            try {
+                $calibrated = $this->calibrations->findForModel($model::class);
+
+                if ($calibrated !== null) {
+                    return $calibrated;
+                }
+            } catch (Throwable) {
+                // DB unavailable / table missing: fall through to next layer
             }
         }
 

--- a/tests/Console/CalibrateCommandTest.php
+++ b/tests/Console/CalibrateCommandTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
+use Spiritix\LadaCache\Console\CalibrateCommand;
+use Spiritix\LadaCache\Tests\Database\Models\Car;
+use Spiritix\LadaCache\Tests\TestCase;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class CalibrateCommandTest extends TestCase
+{
+    private string $sandboxTable = 'lada_cache_calibrations_cmd_test';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['lada-cache.enable_debugbar' => false]);
+
+        Schema::dropIfExists($this->sandboxTable);
+        Schema::create($this->sandboxTable, function (Blueprint $t): void {
+            $t->id();
+            $t->string('model_class')->unique();
+            $t->string('table_name')->index();
+            $t->unsignedInteger('calibrated_ttl');
+            $t->json('metrics');
+            $t->timestamp('calibrated_at');
+            $t->timestamps();
+        });
+
+        Config::set('lada-cache.active', true);
+        Config::set('lada-cache.calibration.enabled', true);
+        Config::set('lada-cache.calibration.min_samples', 1);
+        Config::set('lada-cache.calibration.safety_factor', 2.0);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists($this->sandboxTable);
+        parent::tearDown();
+    }
+
+    public function testCommandExitsCleanlyWhenLadaDisabled(): void
+    {
+        Config::set('lada-cache.active', false);
+
+        $this->assertSame(Command::SUCCESS, $this->runCalibrateCommand([]));
+    }
+
+    public function testCommandConstructibleWithoutDependenciesWhenDisabled(): void
+    {
+        // Service provider instantiates `new CalibrateCommand()` (no deps) when Lada
+        // is disabled; the graceful SUCCESS path must work without redis/repo bound.
+        Config::set('lada-cache.active', false);
+
+        $command = new CalibrateCommand;
+        $command->setLaravel($this->app);
+
+        $exit = $command->run(new ArrayInput([]), new BufferedOutput);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+    }
+
+    public function testCommandFailsLoudlyWhenActiveButDepsMissing(): void
+    {
+        // Defensive guard: misconfig (active=true but deps null) must FAIL with a
+        // descriptive message rather than silently succeed.
+        Config::set('lada-cache.active', true);
+
+        $command = new CalibrateCommand;
+        $command->setLaravel($this->app);
+
+        $exit = $command->run(new ArrayInput([]), new BufferedOutput);
+
+        $this->assertSame(Command::FAILURE, $exit);
+    }
+
+    public function testCommandExitsCleanlyWhenCalibrationDisabled(): void
+    {
+        Config::set('lada-cache.calibration.enabled', false);
+
+        $this->assertSame(Command::SUCCESS, $this->runCalibrateCommand([]));
+    }
+
+    public function testCommandRejectsInvalidModelArgument(): void
+    {
+        // discover() returns []; command warns and exits success (not a fatal error).
+        $exit = $this->runCalibrateCommand(['--model' => '\\Not\\A\\Real\\Class']);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+    }
+
+    public function testDryRunReportsMetricsWithoutPersisting(): void
+    {
+        $this->seedCacheEntriesForCars(samples: 3);
+
+        $exit = $this->runCalibrateCommand(['--model' => Car::class]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertSame(0, DB::table($this->sandboxTable)->count(), 'Dry-run must not persist rows.');
+    }
+
+    public function testApplyPersistsCalibratedTtlRow(): void
+    {
+        $this->seedCacheEntriesForCars(samples: 3);
+
+        $exit = $this->runCalibrateCommand(['--model' => Car::class, '--apply' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+
+        $row = DB::table($this->sandboxTable)->where('model_class', Car::class)->first();
+        $this->assertNotNull($row, '--apply must persist a calibration row.');
+        $this->assertSame('cars', $row->table_name);
+        // Freshly seeded keys can have OBJECT IDLETIME = 0 → calibrated_ttl 0 is valid; assert >= 0.
+        $this->assertGreaterThanOrEqual(0, (int) $row->calibrated_ttl);
+
+        $metrics = json_decode($row->metrics, true);
+        $this->assertGreaterThanOrEqual(3, $metrics['samples']);
+        $this->assertArrayHasKey('p95', $metrics);
+    }
+
+    public function testSkipsModelWhenSamplesBelowMinThreshold(): void
+    {
+        Config::set('lada-cache.calibration.min_samples', 1000);
+        $this->seedCacheEntriesForCars(samples: 3);
+
+        $exit = $this->runCalibrateCommand(['--model' => Car::class, '--apply' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertSame(0, DB::table($this->sandboxTable)->count(), 'Below-threshold models must not be persisted.');
+    }
+
+    public function testRejectsNonPositiveSafetyFactor(): void
+    {
+        $this->seedCacheEntriesForCars(samples: 3);
+
+        $exitZero = $this->runCalibrateCommand(['--model' => Car::class, '--apply' => true, '--safety-factor' => '0']);
+        $this->assertSame(Command::INVALID, $exitZero, 'safety-factor=0 must abort with INVALID.');
+
+        $exitNeg = $this->runCalibrateCommand(['--model' => Car::class, '--apply' => true, '--safety-factor' => '-1']);
+        $this->assertSame(Command::INVALID, $exitNeg, 'safety-factor<0 must abort with INVALID.');
+
+        $this->assertSame(0, DB::table($this->sandboxTable)->count(), 'Invalid safety-factor must not persist rows.');
+    }
+
+    public function testSkipsModelWithZeroSamplesEvenWhenMinThresholdZero(): void
+    {
+        Config::set('lada-cache.calibration.min_samples', 0);
+        // No seeding → samples will be 0.
+
+        $exit = $this->runCalibrateCommand(['--model' => Car::class, '--apply' => true]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertSame(0, DB::table($this->sandboxTable)->count(), 'Zero-sample model must never be persisted regardless of min_samples.');
+    }
+
+    public function testApplyRespectsFloorAgainstSurvivorBias(): void
+    {
+        // Establish a current TTL via config so the floor can be computed.
+        Config::set('lada-cache.model_ttls', [Car::class => 1000]);
+        $this->seedCacheEntriesForCars(samples: 3);
+        // Freshly seeded → P95 ≈ 0, so raw_calibrated ≈ 0. Floor should pull it to 500.
+
+        $this->runCalibrateCommand(['--model' => Car::class, '--apply' => true]);
+
+        $row = DB::table($this->sandboxTable)->where('model_class', Car::class)->first();
+        $this->assertNotNull($row);
+        $this->assertSame(500, (int) $row->calibrated_ttl, 'Floor should clamp to previous_ttl / 2 = 500.');
+
+        $metrics = json_decode($row->metrics, true);
+        $this->assertSame(1000, $metrics['previous_ttl']);
+        $this->assertSame(500, $metrics['floor']);
+        $this->assertArrayHasKey('raw_calibrated', $metrics);
+        $this->assertArrayHasKey('safety_factor', $metrics);
+    }
+
+    public function testFloorDoesNotClampWhenRawIsHigher(): void
+    {
+        Config::set('lada-cache.model_ttls', [Car::class => 10]);
+        $this->seedCacheEntriesForCars(samples: 3);
+        sleep(2);
+        // P95 IDLETIME ≈ 2, raw_calibrated = 2 × 10 = 20; floor = 10/2 = 5; max(20, 5) = 20
+
+        $this->runCalibrateCommand([
+            '--model' => Car::class,
+            '--apply' => true,
+            '--safety-factor' => '10',
+        ]);
+
+        $row = DB::table($this->sandboxTable)->where('model_class', Car::class)->first();
+        $this->assertNotNull($row);
+        $metrics = json_decode($row->metrics, true);
+        $this->assertSame(5, $metrics['floor']);
+        $this->assertGreaterThanOrEqual($metrics['raw_calibrated'], (int) $row->calibrated_ttl);
+        $this->assertGreaterThan($metrics['floor'], (int) $row->calibrated_ttl, 'raw_calibrated > floor → floor must not clamp.');
+    }
+
+    public function testApplyUsesSafetyFactorOverride(): void
+    {
+        $this->seedCacheEntriesForCars(samples: 3);
+        // Ensure OBJECT IDLETIME advances ≥1s so factor differences materialize.
+        sleep(1);
+
+        $this->runCalibrateCommand(['--model' => Car::class, '--apply' => true, '--safety-factor' => '1']);
+        $rowOne = DB::table($this->sandboxTable)->where('model_class', Car::class)->first();
+
+        DB::table($this->sandboxTable)->truncate();
+
+        $this->runCalibrateCommand(['--model' => Car::class, '--apply' => true, '--safety-factor' => '10']);
+        $rowTen = DB::table($this->sandboxTable)->where('model_class', Car::class)->first();
+
+        $this->assertNotNull($rowOne);
+        $this->assertNotNull($rowTen);
+        // 10x factor must produce at least as large a TTL; with P95≥1 the inequality is strict.
+        $this->assertGreaterThanOrEqual((int) $rowOne->calibrated_ttl, (int) $rowTen->calibrated_ttl);
+    }
+
+    public function testFullDiscoveryPicksUpModelsUsingLadaCacheTrait(): void
+    {
+        // No --model filter → discoverModels() walks the configured namespace. Car uses
+        // LadaCacheTrait — smoke test that the discovery path actually finds it
+        // end-to-end (file scan → reflection → table resolve → upsert).
+        $this->seedCacheEntriesForCars(samples: 3);
+
+        $exit = $this->runCalibrateCommand([
+            '--apply' => true,
+            '--models-path' => realpath(__DIR__.'/../Database/Models'),
+            '--models-namespace' => 'Spiritix\\LadaCache\\Tests\\Database\\Models',
+        ]);
+
+        $this->assertSame(Command::SUCCESS, $exit);
+        $this->assertNotNull(
+            DB::table($this->sandboxTable)->where('model_class', Car::class)->first(),
+            'Full-scan discovery must include Car (LadaCacheTrait).',
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Run the calibrate command against the sandboxed calibrations table.
+     * Bypasses the container singleton (which points at the real table) by invoking
+     * the command directly with explicit input/output.
+     *
+     * @param array<string, scalar|bool> $options
+     */
+    private function runCalibrateCommand(array $options): int
+    {
+        $command = new CalibrateCommand(
+            app('lada.redis'),
+            new TtlCalibrationRepository($this->sandboxTable),
+        );
+        $command->setLaravel($this->app);
+
+        return $command->run(new ArrayInput($options), new BufferedOutput);
+    }
+
+    /**
+     * Seed N tagged cache entries for the `cars` table so the command has something to measure.
+     */
+    private function seedCacheEntriesForCars(int $samples): void
+    {
+        /** @var \Spiritix\LadaCache\Cache $cache */
+        $cache = app('lada.cache');
+        $database = (string) config('database.connections.'.config('database.default').'.database');
+        $tag = sprintf('tags:database:%s:table_specific:cars', $database);
+
+        for ($i = 0; $i < $samples; $i++) {
+            $cache->set(sprintf('test-calibrate-car-%d', $i), [$tag], ['v' => $i], 3600);
+        }
+    }
+}

--- a/tests/Console/CalibrateScheduleTest.php
+++ b/tests/Console/CalibrateScheduleTest.php
@@ -6,6 +6,8 @@ namespace Spiritix\LadaCache\Tests\Console;
 
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Support\Facades\Config;
+use ReflectionMethod;
+use Spiritix\LadaCache\LadaCacheServiceProvider;
 use Spiritix\LadaCache\Tests\TestCase;
 
 class CalibrateScheduleTest extends TestCase
@@ -16,50 +18,57 @@ class CalibrateScheduleTest extends TestCase
         config(['lada-cache.enable_debugbar' => false]);
     }
 
-    public function testScheduleIsRegisteredWhenEnabledWithCron(): void
+    public function testScheduleIntervalRegistersDailyCalibrationWhenEnabled(): void
     {
         Config::set('lada-cache.calibration.enabled', true);
-        Config::set('lada-cache.calibration.schedule', '0 3 * * 0');
+        Config::set('lada-cache.calibration.schedule_interval', 7);
 
         $events = $this->resolveScheduledCalibrationEvents();
 
         $this->assertCount(1, $events, 'Calibrate command must be scheduled exactly once.');
-        $this->assertSame('0 3 * * 0', $events[0]->expression);
+        $this->assertSame('0 3 * * *', $events[0]->expression);
     }
 
     public function testScheduleIsNotRegisteredWhenCalibrationDisabled(): void
     {
         Config::set('lada-cache.calibration.enabled', false);
-        Config::set('lada-cache.calibration.schedule', '0 3 * * 0');
+        Config::set('lada-cache.calibration.schedule_interval', 7);
 
         $this->assertCount(
             0,
             $this->resolveScheduledCalibrationEvents(),
-            'Disabled calibration must not register the cron.',
+            'Disabled calibration must not register the schedule.',
         );
     }
 
-    public function testScheduleIsNotRegisteredWhenCronStringEmpty(): void
+    public function testScheduleIsNotRegisteredWhenScheduleIntervalIsZero(): void
     {
         Config::set('lada-cache.calibration.enabled', true);
-        Config::set('lada-cache.calibration.schedule', '');
+        Config::set('lada-cache.calibration.schedule_interval', 0);
 
         $this->assertCount(
             0,
             $this->resolveScheduledCalibrationEvents(),
-            'Empty cron string must opt out of auto-schedule.',
+            'Zero schedule interval must opt out of auto-schedule.',
         );
     }
 
-    public function testCustomCronExpressionIsRespected(): void
+    public function testScheduleIntervalGateMatchesEveryNthDay(): void
     {
         Config::set('lada-cache.calibration.enabled', true);
-        Config::set('lada-cache.calibration.schedule', '*/15 * * * *');
+        Config::set('lada-cache.calibration.schedule_interval', 3);
 
         $events = $this->resolveScheduledCalibrationEvents();
 
         $this->assertCount(1, $events);
-        $this->assertSame('*/15 * * * *', $events[0]->expression);
+        $this->assertSame('0 3 * * *', $events[0]->expression);
+
+        $method = new ReflectionMethod(LadaCacheServiceProvider::class, 'calibrationScheduleIntervalMatches');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke(null, 3, 3 * 86400));
+        $this->assertFalse($method->invoke(null, 3, 4 * 86400));
+        $this->assertTrue($method->invoke(null, 1, 4 * 86400));
     }
 
     /**

--- a/tests/Console/CalibrateScheduleTest.php
+++ b/tests/Console/CalibrateScheduleTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Console;
+
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\Facades\Config;
+use Spiritix\LadaCache\Tests\TestCase;
+
+class CalibrateScheduleTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['lada-cache.enable_debugbar' => false]);
+    }
+
+    public function testScheduleIsRegisteredWhenEnabledWithCron(): void
+    {
+        Config::set('lada-cache.calibration.enabled', true);
+        Config::set('lada-cache.calibration.schedule', '0 3 * * 0');
+
+        $events = $this->resolveScheduledCalibrationEvents();
+
+        $this->assertCount(1, $events, 'Calibrate command must be scheduled exactly once.');
+        $this->assertSame('0 3 * * 0', $events[0]->expression);
+    }
+
+    public function testScheduleIsNotRegisteredWhenCalibrationDisabled(): void
+    {
+        Config::set('lada-cache.calibration.enabled', false);
+        Config::set('lada-cache.calibration.schedule', '0 3 * * 0');
+
+        $this->assertCount(
+            0,
+            $this->resolveScheduledCalibrationEvents(),
+            'Disabled calibration must not register the cron.',
+        );
+    }
+
+    public function testScheduleIsNotRegisteredWhenCronStringEmpty(): void
+    {
+        Config::set('lada-cache.calibration.enabled', true);
+        Config::set('lada-cache.calibration.schedule', '');
+
+        $this->assertCount(
+            0,
+            $this->resolveScheduledCalibrationEvents(),
+            'Empty cron string must opt out of auto-schedule.',
+        );
+    }
+
+    public function testCustomCronExpressionIsRespected(): void
+    {
+        Config::set('lada-cache.calibration.enabled', true);
+        Config::set('lada-cache.calibration.schedule', '*/15 * * * *');
+
+        $events = $this->resolveScheduledCalibrationEvents();
+
+        $this->assertCount(1, $events);
+        $this->assertSame('*/15 * * * *', $events[0]->expression);
+    }
+
+    /**
+     * Resolve the Schedule fresh after applying config — `callAfterResolving` fires
+     * once per container resolution, so we forget any cached binding first.
+     *
+     * @return array<int, \Illuminate\Console\Scheduling\Event>
+     */
+    private function resolveScheduledCalibrationEvents(): array
+    {
+        $this->app->forgetInstance(Schedule::class);
+        /** @var Schedule $schedule */
+        $schedule = $this->app->make(Schedule::class);
+
+        return array_values(array_filter(
+            $schedule->events(),
+            static fn ($event): bool => str_contains((string) $event->command, 'lada-cache:calibrate'),
+        ));
+    }
+}

--- a/tests/Integration/Cache/PerModelTtlTest.php
+++ b/tests/Integration/Cache/PerModelTtlTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Integration\Cache;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+use Spiritix\LadaCache\Contracts\HasLadaTtl;
+use Spiritix\LadaCache\Redis as LadaRedis;
+use Spiritix\LadaCache\Tests\TestCase;
+use Spiritix\LadaCache\TtlResolver;
+
+class PerModelTtlTest extends TestCase
+{
+    // ------------------------------------------------------------------
+    // TtlResolver: fallback chain
+    // ------------------------------------------------------------------
+
+    public function testResolveReturnsNullForNullModel(): void
+    {
+        $resolver = new TtlResolver();
+
+        $this->assertNull($resolver->resolve(null));
+    }
+
+    public function testResolveReturnsNullWhenNoOverridePresent(): void
+    {
+        Config::set('lada-cache.model_ttls', []);
+        $resolver = new TtlResolver();
+
+        $this->assertNull($resolver->resolve(new PlainFixture()));
+    }
+
+    public function testResolveUsesConfigModelTtlsWhenNoInterface(): void
+    {
+        Config::set('lada-cache.model_ttls', [PlainFixture::class => 7200]);
+        $resolver = new TtlResolver();
+
+        $this->assertSame(7200, $resolver->resolve(new PlainFixture()));
+    }
+
+    public function testResolvePrefersInterfaceOverConfig(): void
+    {
+        // Fixture returns 60; config says 9999 — interface wins
+        Config::set('lada-cache.model_ttls', [HasTtlFixture::class => 9999]);
+        $resolver = new TtlResolver();
+
+        $this->assertSame(60, $resolver->resolve(new HasTtlFixture()));
+    }
+
+    public function testResolveFallsBackToConfigWhenInterfaceReturnsNull(): void
+    {
+        Config::set('lada-cache.model_ttls', [HasTtlNullFixture::class => 1800]);
+        $resolver = new TtlResolver();
+
+        $this->assertSame(1800, $resolver->resolve(new HasTtlNullFixture()));
+    }
+
+    public function testResolveReturnsZeroWhenInterfaceExplicitlyReturnsZero(): void
+    {
+        // 0 = "persist forever" — distinct from null = defer to fallback
+        $resolver = new TtlResolver();
+
+        $this->assertSame(0, $resolver->resolve(new HasTtlZeroFixture()));
+    }
+
+    // ------------------------------------------------------------------
+    // Cache::set: TTL semantics with per-model values
+    // ------------------------------------------------------------------
+
+    public function testCacheSetUsesExplicitTtlWhenProvided(): void
+    {
+        $cache = app('lada.cache');
+        $redis = new LadaRedis();
+
+        $cache->set('explicit-ttl-key', ['t:tag'], ['data' => 1], 120);
+
+        $ttl = (int) $redis->ttl($redis->prefix('explicit-ttl-key'));
+
+        // Allow ±5s drift; should be ~120
+        $this->assertGreaterThan(115, $ttl);
+        $this->assertLessThanOrEqual(120, $ttl);
+    }
+
+    public function testCacheSetZeroTtlPersistsForever(): void
+    {
+        $cache = app('lada.cache');
+        $redis = new LadaRedis();
+
+        $cache->set('zero-ttl-key', ['t:tag'], ['data' => 1], 0);
+
+        // Redis TTL = -1 means key exists with no expiration
+        $this->assertSame(-1, (int) $redis->ttl($redis->prefix('zero-ttl-key')));
+    }
+
+    public function testCacheSetNullTtlFallsBackToGlobal(): void
+    {
+        Config::set('lada-cache.expiration_time', 300);
+        // Re-resolve because Cache reads expiration_time at construction
+        app()->forgetInstance('lada.cache');
+
+        $cache = app('lada.cache');
+        $redis = new LadaRedis();
+
+        $cache->set('null-ttl-key', ['t:tag'], ['data' => 1], null);
+
+        $ttl = (int) $redis->ttl($redis->prefix('null-ttl-key'));
+        $this->assertGreaterThan(295, $ttl);
+        $this->assertLessThanOrEqual(300, $ttl);
+    }
+}
+
+// ------------------------------------------------------------------
+// Minimal fixtures — Eloquent models implementing HasLadaTtl
+// ------------------------------------------------------------------
+
+class PlainFixture extends Model
+{
+}
+
+class HasTtlFixture extends Model implements HasLadaTtl
+{
+    public function getLadaTtl(): ?int
+    {
+        return 60;
+    }
+}
+
+class HasTtlNullFixture extends Model implements HasLadaTtl
+{
+    public function getLadaTtl(): ?int
+    {
+        return null;
+    }
+}
+
+class HasTtlZeroFixture extends Model implements HasLadaTtl
+{
+    public function getLadaTtl(): ?int
+    {
+        return 0;
+    }
+}

--- a/tests/Unit/Calibration/HitRatioAdjustmentTest.php
+++ b/tests/Unit/Calibration/HitRatioAdjustmentTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Unit\Calibration;
+
+use PHPUnit\Framework\TestCase;
+use Spiritix\LadaCache\Calibration\HitRatioAdjustment;
+
+/**
+ * Algorithm-level unit tests for the convergent hit_ratio adjustment used by
+ * CalibrateCommand. Integration tests live in CalibrateCommandTest; here we
+ * verify the mathematical properties in isolation:
+ *
+ *   1. No-op when hit_ratio is null (no signal)
+ *   2. No-op inside the hysteresis deadband
+ *   3. Proportional adjustment within the bounded clamp
+ *   4. Hard clamp at ±max_step for extreme deviations
+ *   5. Fixed point: hit_ratio == target → adjustment == 1 → TTL unchanged
+ *   6. Bounded contraction: repeated runs converge geometrically (no oscillation)
+ */
+class HitRatioAdjustmentTest extends TestCase
+{
+    public function test_returns_raw_when_hit_ratio_is_null(): void
+    {
+        // No signal → no adjustment, idletime-only path.
+        $this->assertSame(
+            1000,
+            HitRatioAdjustment::apply(1000, null, 0.80, 0.05, 0.30, 0.20),
+        );
+    }
+
+    public function test_returns_raw_when_deviation_within_deadband(): void
+    {
+        // hit_ratio=0.78, target=0.80 → deviation=0.02 < deadband=0.05 → no-op.
+        $this->assertSame(
+            1000,
+            HitRatioAdjustment::apply(1000, 0.78, 0.80, 0.05, 0.30, 0.20),
+        );
+
+        // Symmetric: hit_ratio=0.82 → deviation=-0.02 → still no-op.
+        $this->assertSame(
+            1000,
+            HitRatioAdjustment::apply(1000, 0.82, 0.80, 0.05, 0.30, 0.20),
+        );
+    }
+
+    public function test_grows_ttl_when_hit_ratio_below_target_outside_deadband(): void
+    {
+        // hit_ratio=0.50, target=0.80 → deviation=0.30
+        // adj = 1 + 0.30 × 0.30 = 1.09 (clamp irrelevant, |0.09| < 0.20)
+        // raw=1000 → ceil(1000 × 1.09) = 1090.
+        $this->assertSame(
+            1090,
+            HitRatioAdjustment::apply(1000, 0.50, 0.80, 0.05, 0.30, 0.20),
+        );
+    }
+
+    public function test_shrinks_ttl_when_hit_ratio_above_target_outside_deadband(): void
+    {
+        // hit_ratio=0.95, target=0.80 → deviation=-0.15
+        // adj = 1 + 0.30 × (-0.15) = 0.955 (float: 0.95500000000001)
+        // raw=1000 → ceil(955.0000000001) = 956 — rounding up by one second is the
+        // safe direction here (cache stays slightly longer); rounding down would
+        // collide with the survivor-bias guard.
+        $this->assertSame(
+            956,
+            HitRatioAdjustment::apply(1000, 0.95, 0.80, 0.05, 0.30, 0.20),
+        );
+    }
+
+    public function test_caps_growth_at_max_step_for_extreme_low_hit_ratio(): void
+    {
+        // hit_ratio=0.10, target=0.80 → deviation=0.70
+        // raw_adj = 1 + 0.30 × 0.70 = 1.21 → clamped to 1.20.
+        // raw=1000 → ceil(1000 × 1.20) = 1200.
+        $this->assertSame(
+            1200,
+            HitRatioAdjustment::apply(1000, 0.10, 0.80, 0.05, 0.30, 0.20),
+        );
+
+        // hit_ratio=0.00 (pathological worst case) → deviation=0.80
+        // raw_adj = 1.24 → clamped to 1.20 (same).
+        $this->assertSame(
+            1200,
+            HitRatioAdjustment::apply(1000, 0.00, 0.80, 0.05, 0.30, 0.20),
+        );
+    }
+
+    public function test_caps_shrink_at_max_step_for_extreme_high_hit_ratio(): void
+    {
+        // Pathological: hit_ratio=1.00, very high learning_rate=2.0 to force clamp.
+        // deviation = 0.80 - 1.00 = -0.20
+        // raw_adj = 1 + 2.0 × (-0.20) = 0.60 → clamped to 0.80.
+        // raw=1000 → ceil(1000 × 0.80) = 800.
+        $this->assertSame(
+            800,
+            HitRatioAdjustment::apply(1000, 1.00, 0.80, 0.05, 2.0, 0.20),
+        );
+    }
+
+    public function test_fixed_point_when_hit_ratio_equals_target(): void
+    {
+        // deviation=0 < deadband → no-op. Stable: future runs at this hit_ratio
+        // produce the same TTL. (Convergence pre-condition.)
+        $this->assertSame(
+            1000,
+            HitRatioAdjustment::apply(1000, 0.80, 0.80, 0.05, 0.30, 0.20),
+        );
+    }
+
+    public function test_iterative_application_converges_into_deadband(): void
+    {
+        // Simulate cron repeating: each run uses previous TTL as input. With
+        // hit_ratio held BELOW target, TTL should grow toward stability.
+        // We don't model the actual hit_ratio response curve here — just verify
+        // that monotonic input produces bounded change per step (no overshoot).
+        $ttl = 1000;
+        $maxChangePerStep = 0.20; // matches max_step
+
+        for ($i = 0; $i < 5; $i++) {
+            $newTtl = HitRatioAdjustment::apply($ttl, 0.40, 0.80, 0.05, 0.30, 0.20);
+            $ratio = $newTtl / $ttl;
+
+            // Per-step change must stay within ±max_step (bounded contraction).
+            $this->assertGreaterThanOrEqual(1.0 - $maxChangePerStep, $ratio, "step {$i}");
+            $this->assertLessThanOrEqual(1.0 + $maxChangePerStep, $ratio, "step {$i}");
+
+            $ttl = $newTtl;
+        }
+
+        // After 5 runs at 12% growth (clamp not binding): 1000 × 1.12^5 ≈ 1762.
+        $this->assertGreaterThan(1500, $ttl);
+        $this->assertLessThan(2000, $ttl);
+    }
+
+    public function test_negative_config_values_are_clamped_defensively(): void
+    {
+        // Negative deadband / learning_rate / max_step would otherwise produce
+        // nonsensical results (inverted direction, ever-shrinking TTL). The
+        // function clamps them to 0 internally → safe degradation.
+
+        // Negative deadband → treated as 0 → adjustment still applies.
+        $this->assertSame(
+            1090,
+            HitRatioAdjustment::apply(1000, 0.50, 0.80, -0.05, 0.30, 0.20),
+        );
+
+        // Negative learning_rate → treated as 0 → no movement at all.
+        $this->assertSame(
+            1000,
+            HitRatioAdjustment::apply(1000, 0.50, 0.80, 0.05, -0.30, 0.20),
+        );
+
+        // Negative max_step → treated as 0 → clamp to exactly [1, 1] → no change.
+        $this->assertSame(
+            1000,
+            HitRatioAdjustment::apply(1000, 0.50, 0.80, 0.05, 0.30, -0.20),
+        );
+    }
+
+    public function test_max_step_above_one_is_capped_to_protect_lower_bound(): void
+    {
+        // Without a ceiling, max_step=2.0 + high learning_rate + hit_ratio above
+        // target would drive `1 - max_step = -1`, allowing adjustment <= 0 →
+        // ceil(raw × adj) ≤ 0. The MAX_STEP_CEILING (0.95) keeps the lower
+        // clamp at 0.05:
+        //   raw_adj = 1 + 5.0 × (-0.5) = -1.5 → clamp(-1.5, 0.05, 1.95) = 0.05
+        //   raw=1000 → ceil(1000 × 0.05) = 50 (well above zero).
+        $this->assertGreaterThanOrEqual(
+            50,
+            HitRatioAdjustment::apply(1000, 1.00, 0.50, 0.05, 5.0, 2.0),
+        );
+    }
+
+    public function test_result_is_never_zero_or_negative(): void
+    {
+        // Defensive last-resort floor. TTL=0 in Lada means "persist forever"
+        // (Cache::set drops the EX argument), so a misconfigured input that
+        // produces TTL ≤ 0 would silently leak memory when invalidation misses.
+        // max(1, ...) is the final guarantee.
+        //
+        // Worst-case combination: tiny raw + max_step above ceiling +
+        // extreme learning rate + maximum deviation.
+        $result = HitRatioAdjustment::apply(1, 1.00, 0.00, 0.0, 100.0, 999.0);
+
+        $this->assertGreaterThanOrEqual(1, $result, 'TTL must never be zero or negative under any input.');
+    }
+}

--- a/tests/Unit/Calibration/TtlCalibrationRepositoryTest.php
+++ b/tests/Unit/Calibration/TtlCalibrationRepositoryTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Unit\Calibration;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spiritix\LadaCache\Calibration\TtlCalibrationRepository;
+use Spiritix\LadaCache\Tests\Database\Models\Car;
+use Spiritix\LadaCache\Tests\TestCase;
+use Spiritix\LadaCache\TtlResolver;
+
+class TtlCalibrationRepositoryTest extends TestCase
+{
+    private string $sandboxTable = 'lada_cache_calibrations_test';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Sandbox calibration table so we never touch shared rows and the suite
+        // stays hermetic when run repeatedly.
+        Schema::dropIfExists($this->sandboxTable);
+        Schema::create($this->sandboxTable, function (Blueprint $t): void {
+            $t->id();
+            $t->string('model_class')->unique();
+            $t->string('table_name')->index();
+            $t->unsignedInteger('calibrated_ttl');
+            $t->json('metrics');
+            $t->timestamp('calibrated_at');
+            $t->timestamps();
+        });
+
+        Cache::forget(TtlCalibrationRepository::CACHE_KEY);
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists($this->sandboxTable);
+        Cache::forget(TtlCalibrationRepository::CACHE_KEY);
+
+        parent::tearDown();
+    }
+
+    public function testFindForModelReturnsNullWhenNoRowExists(): void
+    {
+        $repo = new TtlCalibrationRepository($this->sandboxTable);
+
+        $this->assertNull($repo->findForModel(Car::class));
+    }
+
+    public function testUpsertThenFindReturnsCalibratedTtl(): void
+    {
+        $repo = new TtlCalibrationRepository($this->sandboxTable);
+
+        $repo->upsert(Car::class, 'cars', 600, ['samples' => 100, 'p50' => 120, 'p95' => 300, 'max' => 500]);
+
+        $this->assertSame(600, $repo->findForModel(Car::class));
+
+        $row = DB::table($this->sandboxTable)->where('model_class', Car::class)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('cars', $row->table_name);
+        $this->assertSame(600, (int) $row->calibrated_ttl);
+
+        $metrics = json_decode($row->metrics, true);
+        $this->assertSame(100, $metrics['samples']);
+        $this->assertSame(300, $metrics['p95']);
+    }
+
+    public function testUpsertIsIdempotentAndOverwrites(): void
+    {
+        $repo = new TtlCalibrationRepository($this->sandboxTable);
+
+        $repo->upsert(Car::class, 'cars', 600, ['samples' => 100]);
+        $repo->upsert(Car::class, 'cars', 1200, ['samples' => 200]);
+
+        $this->assertSame(1200, $repo->findForModel(Car::class));
+        $this->assertSame(1, DB::table($this->sandboxTable)->where('model_class', Car::class)->count());
+    }
+
+    public function testMapIsCachedUntilBust(): void
+    {
+        Config::set('lada-cache.calibration.cache_ttl', 60);
+        $repo = new TtlCalibrationRepository($this->sandboxTable);
+
+        $repo->upsert(Car::class, 'cars', 600, ['samples' => 100]);
+        $this->assertSame(600, $repo->findForModel(Car::class));
+
+        // Mutate the DB directly — without bust(), repo should still return cached value.
+        DB::table($this->sandboxTable)
+            ->where('model_class', Car::class)
+            ->update(['calibrated_ttl' => 9999])
+        ;
+
+        $this->assertSame(600, $repo->findForModel(Car::class));
+
+        $repo->bust();
+        $this->assertSame(9999, $repo->findForModel(Car::class));
+    }
+
+    public function testResolverPrefersCalibratedOverConfigWhenEnabled(): void
+    {
+        Config::set('lada-cache.calibration.enabled', true);
+        Config::set('lada-cache.model_ttls', [Car::class => 7200]);
+
+        $repo = new TtlCalibrationRepository($this->sandboxTable);
+        $repo->upsert(Car::class, 'cars', 300, ['samples' => 100]);
+
+        $resolver = new TtlResolver($repo);
+
+        $this->assertSame(300, $resolver->resolve(new Car));
+    }
+
+    public function testResolverSkipsCalibrationWhenFlagDisabled(): void
+    {
+        Config::set('lada-cache.calibration.enabled', false);
+        Config::set('lada-cache.model_ttls', [Car::class => 7200]);
+
+        $repo = new TtlCalibrationRepository($this->sandboxTable);
+        $repo->upsert(Car::class, 'cars', 300, ['samples' => 100]);
+
+        $resolver = new TtlResolver($repo);
+
+        // Calibration ignored → falls through to model_ttls config
+        $this->assertSame(7200, $resolver->resolve(new Car));
+    }
+
+    public function testResolverSwallowsDbErrorsDuringCalibrationLookup(): void
+    {
+        Config::set('lada-cache.calibration.enabled', true);
+        Config::set('lada-cache.model_ttls', [Car::class => 7200]);
+        Cache::forget(TtlCalibrationRepository::CACHE_KEY);
+
+        // Point repository at a non-existent table → DB error on read.
+        $repo = new TtlCalibrationRepository('lada_cache_calibrations_missing_table');
+        $resolver = new TtlResolver($repo);
+
+        // Should fall through to config rather than throwing.
+        $this->assertSame(7200, $resolver->resolve(new Car));
+    }
+}

--- a/tests/Unit/QueryHandlerTest.php
+++ b/tests/Unit/QueryHandlerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Spiritix\LadaCache\Tests\Unit;
 
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Spiritix\LadaCache\Cache;
 use Spiritix\LadaCache\Encoder;
+use Spiritix\LadaCache\Events\LadaCacheActivity;
 use Spiritix\LadaCache\Hasher;
 use Spiritix\LadaCache\Invalidator;
 use Spiritix\LadaCache\QueryHandler;
@@ -89,5 +91,34 @@ class QueryHandlerTest extends TestCase
         foreach ($tags as $tag) {
             $this->assertSame(1, (int) $this->redis->sismember($this->redis->prefix($tag), $this->redis->prefix($key)));
         }
+    }
+
+    public function testCacheActivityFollowsCalibrationEnabledFlag(): void
+    {
+        config(['lada-cache.calibration.enabled' => true]);
+        Event::fake([LadaCacheActivity::class]);
+
+        $handler = new QueryHandler($this->cache, $this->invalidator, $this->ttlResolver);
+        $handler->setBuilder(DB::table('cars'));
+
+        $handler->cacheQuery(static fn (): array => [['id' => 1, 'name' => 'car']]);
+
+        Event::assertDispatched(
+            LadaCacheActivity::class,
+            static fn (LadaCacheActivity $event): bool => $event->action === 'miss' && $event->table === 'cars',
+        );
+    }
+
+    public function testCacheActivityIsSilentWhenCalibrationDisabled(): void
+    {
+        config(['lada-cache.calibration.enabled' => false]);
+        Event::fake([LadaCacheActivity::class]);
+
+        $handler = new QueryHandler($this->cache, $this->invalidator, $this->ttlResolver);
+        $handler->setBuilder(DB::table('cars'));
+
+        $handler->cacheQuery(static fn (): array => [['id' => 1, 'name' => 'car']]);
+
+        Event::assertNotDispatched(LadaCacheActivity::class);
     }
 }

--- a/tests/Unit/QueryHandlerTest.php
+++ b/tests/Unit/QueryHandlerTest.php
@@ -14,12 +14,14 @@ use Spiritix\LadaCache\Redis;
 use Spiritix\LadaCache\Reflector;
 use Spiritix\LadaCache\Tagger;
 use Spiritix\LadaCache\Tests\TestCase;
+use Spiritix\LadaCache\TtlResolver;
 
 class QueryHandlerTest extends TestCase
 {
     private Redis $redis;
     private Cache $cache;
     private Invalidator $invalidator;
+    private TtlResolver $ttlResolver;
 
     protected function setUp(): void
     {
@@ -30,11 +32,12 @@ class QueryHandlerTest extends TestCase
         $this->redis = new Redis();
         $this->cache = new Cache($this->redis, new Encoder(), 0);
         $this->invalidator = new Invalidator($this->redis);
+        $this->ttlResolver = new TtlResolver();
     }
 
     public function testCacheQueryMissStoresResultAndTags(): void
     {
-        $handler = new QueryHandler($this->cache, $this->invalidator);
+        $handler = new QueryHandler($this->cache, $this->invalidator, $this->ttlResolver);
         $builder = DB::table('cars');
         $handler->setBuilder($builder);
 
@@ -59,7 +62,7 @@ class QueryHandlerTest extends TestCase
 
     public function testCacheQueryHitReadsCachedValueAndRepairsTags(): void
     {
-        $handler = new QueryHandler($this->cache, $this->invalidator);
+        $handler = new QueryHandler($this->cache, $this->invalidator, $this->ttlResolver);
         $builder = DB::table('cars');
         $handler->setBuilder($builder);
 

--- a/tests/Unit/Stats/StatsCounterTest.php
+++ b/tests/Unit/Stats/StatsCounterTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Unit\Stats;
+
+use Spiritix\LadaCache\Events\LadaCacheActivity;
+use Spiritix\LadaCache\Redis;
+use Spiritix\LadaCache\Stats\StatsCounter;
+use Spiritix\LadaCache\Tests\TestCase;
+
+/**
+ * Unit-level checks for {@see StatsCounter}.
+ *
+ * Verifies:
+ *   - In-memory aggregation per (table, action) field.
+ *   - Auto-flush triggers: distinct-field threshold and time interval.
+ *   - Pipeline writes HINCRBY per field + EXPIRE per bucket.
+ *   - Null table coerces to "unknown" so the counter survives malformed events.
+ *
+ * The counter is exercised directly (not via the event bus) to keep these
+ * deterministic.
+ */
+class StatsCounterTest extends TestCase
+{
+    private Redis $redis;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redis = new Redis;
+    }
+
+    public function test_handle_aggregates_in_memory_until_flush(): void
+    {
+        $counter = $this->makeCounter(maxBatchSize: 1000, maxIntervalSeconds: 1000.0);
+
+        $counter->handle($this->event('hit', 'users'));
+        $counter->handle($this->event('hit', 'users'));
+        $counter->handle($this->event('miss', 'users'));
+        $counter->handle($this->event('hit', 'orders'));
+
+        $this->assertSame([
+            'users:hit' => 2,
+            'users:miss' => 1,
+            'orders:hit' => 1,
+        ], $counter->pending());
+    }
+
+    public function test_flush_writes_hincrby_per_field_and_sets_bucket_ttl(): void
+    {
+        $counter = $this->makeCounter(maxBatchSize: 1000, maxIntervalSeconds: 1000.0, bucketTtlSeconds: 3600);
+
+        $counter->handle($this->event('hit', 'users'));
+        $counter->handle($this->event('hit', 'users'));
+        $counter->handle($this->event('invalidate', 'orders'));
+
+        $counter->flush();
+
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+
+        $this->assertSame('2', (string) $this->redis->hget($bucket, 'users:hit'));
+        $this->assertSame('1', (string) $this->redis->hget($bucket, 'orders:invalidate'));
+
+        $ttl = (int) $this->redis->ttl($bucket);
+        $this->assertGreaterThan(0, $ttl);
+        $this->assertLessThanOrEqual(3600, $ttl);
+
+        // After flush, pending must be empty so the next handle() starts fresh.
+        $this->assertSame([], $counter->pending());
+    }
+
+    public function test_max_batch_size_triggers_auto_flush(): void
+    {
+        $counter = $this->makeCounter(maxBatchSize: 3, maxIntervalSeconds: 1000.0);
+
+        // 3 distinct fields → auto-flush on the 3rd handle.
+        $counter->handle($this->event('hit', 'users'));
+        $counter->handle($this->event('hit', 'orders'));
+        $this->assertCount(2, $counter->pending(), 'no flush yet — under threshold');
+
+        $counter->handle($this->event('hit', 'cities'));
+
+        $this->assertSame([], $counter->pending(), 'auto-flush should fire when distinct field count reaches batch size');
+
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $this->assertSame('1', (string) $this->redis->hget($bucket, 'users:hit'));
+        $this->assertSame('1', (string) $this->redis->hget($bucket, 'orders:hit'));
+        $this->assertSame('1', (string) $this->redis->hget($bucket, 'cities:hit'));
+    }
+
+    public function test_max_interval_seconds_triggers_auto_flush(): void
+    {
+        // Very short interval — first event happens "in the past" relative to lastFlush
+        // because the constructor sets lastFlush to now and the test waits below.
+        $counter = $this->makeCounter(maxBatchSize: 1000, maxIntervalSeconds: 0.05);
+
+        $counter->handle($this->event('hit', 'users'));
+        $this->assertCount(1, $counter->pending());
+
+        usleep(80_000); // 80ms — exceeds 50ms interval
+
+        $counter->handle($this->event('hit', 'orders'));
+
+        $this->assertSame([], $counter->pending(), 'interval threshold should auto-flush both pending events');
+
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $this->assertSame('1', (string) $this->redis->hget($bucket, 'users:hit'));
+        $this->assertSame('1', (string) $this->redis->hget($bucket, 'orders:hit'));
+    }
+
+    public function test_handle_uses_unknown_when_table_is_null(): void
+    {
+        $counter = $this->makeCounter(maxBatchSize: 1000, maxIntervalSeconds: 1000.0);
+
+        $counter->handle(new LadaCacheActivity('hit', 'some-key', [], null));
+
+        $this->assertSame(['unknown:hit' => 1], $counter->pending());
+    }
+
+    public function test_repeat_handle_on_same_field_increments(): void
+    {
+        $counter = $this->makeCounter(maxBatchSize: 1000, maxIntervalSeconds: 1000.0);
+
+        for ($i = 0; $i < 50; $i++) {
+            $counter->handle($this->event('hit', 'users'));
+        }
+
+        $this->assertSame(['users:hit' => 50], $counter->pending());
+
+        $counter->flush();
+
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $this->assertSame('50', (string) $this->redis->hget($bucket, 'users:hit'));
+    }
+
+    public function test_flush_is_no_op_when_pending_empty(): void
+    {
+        $counter = $this->makeCounter(maxBatchSize: 1000, maxIntervalSeconds: 1000.0);
+
+        $counter->flush();
+
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $this->assertSame(0, (int) $this->redis->exists($bucket), 'no Redis key should be created for an empty flush');
+    }
+
+    private function makeCounter(
+        int $maxBatchSize = 100,
+        float $maxIntervalSeconds = 5.0,
+        int $bucketTtlSeconds = 86400 * 7,
+    ): StatsCounter {
+        return new StatsCounter($this->redis, $maxBatchSize, $maxIntervalSeconds, $bucketTtlSeconds);
+    }
+
+    private function event(string $action, ?string $table): LadaCacheActivity
+    {
+        return new LadaCacheActivity($action, 'cache-key-'.$action.'-'.($table ?? 'null'), [], $table);
+    }
+}

--- a/tests/Unit/Stats/StatsCounterTest.php
+++ b/tests/Unit/Stats/StatsCounterTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Spiritix\LadaCache\Tests\Unit\Stats;
 
+use Illuminate\Redis\Connections\Connection;
+use Mockery;
 use Spiritix\LadaCache\Events\LadaCacheActivity;
 use Spiritix\LadaCache\Redis;
 use Spiritix\LadaCache\Stats\StatsCounter;
 use Spiritix\LadaCache\Tests\TestCase;
+use Throwable;
 
 /**
  * Unit-level checks for {@see StatsCounter}.
@@ -58,7 +61,7 @@ class StatsCounterTest extends TestCase
 
         $counter->flush();
 
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
 
         $this->assertSame('2', (string) $this->redis->hget($bucket, 'users:hit'));
         $this->assertSame('1', (string) $this->redis->hget($bucket, 'orders:invalidate'));
@@ -84,7 +87,7 @@ class StatsCounterTest extends TestCase
 
         $this->assertSame([], $counter->pending(), 'auto-flush should fire when distinct field count reaches batch size');
 
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
         $this->assertSame('1', (string) $this->redis->hget($bucket, 'users:hit'));
         $this->assertSame('1', (string) $this->redis->hget($bucket, 'orders:hit'));
         $this->assertSame('1', (string) $this->redis->hget($bucket, 'cities:hit'));
@@ -105,7 +108,7 @@ class StatsCounterTest extends TestCase
 
         $this->assertSame([], $counter->pending(), 'interval threshold should auto-flush both pending events');
 
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
         $this->assertSame('1', (string) $this->redis->hget($bucket, 'users:hit'));
         $this->assertSame('1', (string) $this->redis->hget($bucket, 'orders:hit'));
     }
@@ -131,7 +134,7 @@ class StatsCounterTest extends TestCase
 
         $counter->flush();
 
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
         $this->assertSame('50', (string) $this->redis->hget($bucket, 'users:hit'));
     }
 
@@ -141,8 +144,107 @@ class StatsCounterTest extends TestCase
 
         $counter->flush();
 
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
         $this->assertSame(0, (int) $this->redis->exists($bucket), 'no Redis key should be created for an empty flush');
+    }
+
+    public function test_bucket_key_uses_utc_to_avoid_tz_drift(): void
+    {
+        // Writer should produce the UTC YYYYMMDDHH bucket so that a reader on
+        // a host with a different `date.timezone` still finds the same key.
+        // Regression test for the `date()` → `gmdate()` switch.
+        $counter = $this->makeCounter(maxBatchSize: 1000, maxIntervalSeconds: 1000.0);
+
+        $counter->handle($this->event('hit', 'users'));
+        $counter->flush();
+
+        $utcBucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
+        $this->assertSame(1, (int) $this->redis->exists($utcBucket), 'bucket key must use gmdate(YmdH)');
+        $this->assertSame('1', (string) $this->redis->hget($utcBucket, 'users:hit'));
+    }
+
+    public function test_pipeline_failure_restores_pending_for_retry(): void
+    {
+        // Mock the underlying Connection (Redis itself is final readonly).
+        // pipeline() throws so we can observe the restore path: the next
+        // flush should retry the same batch.
+        $callCount = 0;
+        $redis = $this->redisWithFailingPipeline(function () use (&$callCount): void {
+            $callCount++;
+            throw new \RuntimeException('redis down');
+        });
+
+        $counter = new StatsCounter($redis, maxBatchSize: 1000, maxIntervalSeconds: 1000.0);
+        $counter->handle(new LadaCacheActivity('hit', 'k', [], 'users'));
+        $counter->handle(new LadaCacheActivity('miss', 'k', [], 'users'));
+
+        try {
+            $counter->flush();
+        } catch (Throwable) {
+            // The implementation must swallow flush exceptions; if it
+            // re-throws, the assertion below will catch the regression.
+        }
+
+        $this->assertSame(1, $callCount, 'pipeline was called once');
+        $this->assertSame(
+            ['users:hit' => 1, 'users:miss' => 1],
+            $counter->pending(),
+            'failed flush must restore the batch into pending so the next flush retries it',
+        );
+    }
+
+    public function test_overflow_drops_oldest_when_pending_exceeds_cap(): void
+    {
+        // Force the restore-on-failure path repeatedly with a tiny cap so we
+        // can observe oldest-first eviction without seeding 10k entries.
+        $redis = $this->redisWithFailingPipeline(static function (): void {
+            throw new \RuntimeException('redis still down');
+        });
+
+        $counter = new StatsCounter(
+            $redis,
+            maxBatchSize: 1000,
+            maxIntervalSeconds: 1000.0,
+            bucketTtlSeconds: 3600,
+            maxPendingSize: 3,
+        );
+
+        // Insert 5 distinct fields; pipeline fails each time we flush, the
+        // restore-on-failure path puts them all back into pending, then the
+        // overflow guard trims the oldest 2.
+        $tables = ['a', 'b', 'c', 'd', 'e'];
+        foreach ($tables as $table) {
+            $counter->handle(new LadaCacheActivity('hit', 'k', [], $table));
+        }
+        $counter->flush();
+
+        $remaining = $counter->pending();
+        $this->assertCount(3, $remaining, 'pending must be trimmed to maxPendingSize');
+        $this->assertSame(
+            ['c:hit', 'd:hit', 'e:hit'],
+            array_keys($remaining),
+            'oldest entries must be dropped first (PHP array insertion order)',
+        );
+    }
+
+    /**
+     * Build a real Redis proxy around a stub Connection whose pipeline()
+     * invokes the supplied callback (typically throwing). Used to drive the
+     * restore-on-failure / overflow paths deterministically without touching
+     * a live Redis instance.
+     */
+    private function redisWithFailingPipeline(\Closure $onPipeline): Redis
+    {
+        $connection = Mockery::mock(Connection::class);
+        $connection->shouldReceive('pipeline')->andReturnUsing($onPipeline);
+
+        return new Redis($connection);
+    }
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
     }
 
     private function makeCounter(

--- a/tests/Unit/Stats/StatsReaderTest.php
+++ b/tests/Unit/Stats/StatsReaderTest.php
@@ -32,7 +32,7 @@ class StatsReaderTest extends TestCase
     public function test_read_returns_empty_when_lookback_is_non_positive(): void
     {
         // Seed something so we can verify it isn't read.
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
         $this->redis->hset($bucket, 'users:hit', 5);
 
         $this->assertSame([], $this->reader->readAllActivity(0));
@@ -46,7 +46,7 @@ class StatsReaderTest extends TestCase
 
     public function test_read_aggregates_single_bucket_per_table(): void
     {
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
         $this->redis->hset($bucket, 'users:hit', 100);
         $this->redis->hset($bucket, 'users:miss', 20);
         $this->redis->hset($bucket, 'users:invalidate', 5);
@@ -63,9 +63,9 @@ class StatsReaderTest extends TestCase
     public function test_read_sums_across_multiple_hourly_buckets(): void
     {
         $now = time();
-        $thisHour = $this->redis->prefix('lada:stats:'.date('YmdH', $now));
-        $lastHour = $this->redis->prefix('lada:stats:'.date('YmdH', $now - 3600));
-        $threeHoursAgo = $this->redis->prefix('lada:stats:'.date('YmdH', $now - 3 * 3600));
+        $thisHour = $this->redis->prefix('lada:stats:'.gmdate('YmdH', $now));
+        $lastHour = $this->redis->prefix('lada:stats:'.gmdate('YmdH', $now - 3600));
+        $threeHoursAgo = $this->redis->prefix('lada:stats:'.gmdate('YmdH', $now - 3 * 3600));
 
         $this->redis->hset($thisHour, 'users:hit', 10);
         $this->redis->hset($lastHour, 'users:hit', 20);
@@ -82,7 +82,7 @@ class StatsReaderTest extends TestCase
 
     public function test_read_ignores_malformed_field_names(): void
     {
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
         $this->redis->hset($bucket, 'users:hit', 10);
         $this->redis->hset($bucket, 'no_colon_at_all', 99);      // missing :action
         $this->redis->hset($bucket, 'users:unknown_action', 77); // unknown action label
@@ -94,6 +94,25 @@ class StatsReaderTest extends TestCase
         ], $result, 'Malformed / unknown-action fields must be silently dropped.');
     }
 
+    public function test_read_treats_missing_old_buckets_as_zero_contribution(): void
+    {
+        // Simulates `stats_lookback_hours` > `bucket_ttl_seconds/3600`: only
+        // the recent bucket is populated, older keys do not exist (would have
+        // expired). HGETALL on a missing key returns empty → 0 contribution.
+        $now = time();
+        $thisHour = $this->redis->prefix('lada:stats:'.gmdate('YmdH', $now));
+        $this->redis->hset($thisHour, 'users:hit', 7);
+
+        // Look back 200 hours; only thisHour has data, the rest are missing.
+        $result = $this->reader->readAllActivity(200);
+
+        $this->assertSame(
+            ['users' => ['hit' => 7, 'miss' => 0, 'invalidate' => 0]],
+            $result,
+            'missing (expired) buckets must contribute 0 without failing the read',
+        );
+    }
+
     public function test_read_handles_table_names_with_colon_safely(): void
     {
         // explode(..., 2) limits to 2 parts so a table name containing colons
@@ -102,7 +121,7 @@ class StatsReaderTest extends TestCase
         // hit/miss/invalidate. Realistic table names don't contain colons, but
         // this guards us from quietly producing junk if some downstream emits
         // a weird field.
-        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $bucket = $this->redis->prefix('lada:stats:'.gmdate('YmdH'));
         $this->redis->hset($bucket, 'weird:table:hit', 5);
 
         $result = $this->reader->readAllActivity(1);

--- a/tests/Unit/Stats/StatsReaderTest.php
+++ b/tests/Unit/Stats/StatsReaderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Spiritix\LadaCache\Tests\Unit\Stats;
+
+use Spiritix\LadaCache\Redis;
+use Spiritix\LadaCache\Stats\StatsReader;
+use Spiritix\LadaCache\Tests\TestCase;
+
+/**
+ * Verifies {@see StatsReader} aggregation behavior:
+ *   - Aggregates field counts from a single bucket into per-table totals.
+ *   - Sums across multiple hourly buckets (lookback window).
+ *   - Ignores malformed fields and unknown action labels.
+ *   - Returns empty when lookback is non-positive (no Redis round-trip).
+ */
+class StatsReaderTest extends TestCase
+{
+    private Redis $redis;
+
+    private StatsReader $reader;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->redis = new Redis;
+        $this->reader = new StatsReader($this->redis);
+    }
+
+    public function test_read_returns_empty_when_lookback_is_non_positive(): void
+    {
+        // Seed something so we can verify it isn't read.
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $this->redis->hset($bucket, 'users:hit', 5);
+
+        $this->assertSame([], $this->reader->readAllActivity(0));
+        $this->assertSame([], $this->reader->readAllActivity(-1));
+    }
+
+    public function test_read_returns_empty_when_no_buckets_exist(): void
+    {
+        $this->assertSame([], $this->reader->readAllActivity(24));
+    }
+
+    public function test_read_aggregates_single_bucket_per_table(): void
+    {
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $this->redis->hset($bucket, 'users:hit', 100);
+        $this->redis->hset($bucket, 'users:miss', 20);
+        $this->redis->hset($bucket, 'users:invalidate', 5);
+        $this->redis->hset($bucket, 'orders:hit', 50);
+
+        $result = $this->reader->readAllActivity(1);
+
+        $this->assertSame([
+            'users' => ['hit' => 100, 'miss' => 20, 'invalidate' => 5],
+            'orders' => ['hit' => 50, 'miss' => 0, 'invalidate' => 0],
+        ], $result);
+    }
+
+    public function test_read_sums_across_multiple_hourly_buckets(): void
+    {
+        $now = time();
+        $thisHour = $this->redis->prefix('lada:stats:'.date('YmdH', $now));
+        $lastHour = $this->redis->prefix('lada:stats:'.date('YmdH', $now - 3600));
+        $threeHoursAgo = $this->redis->prefix('lada:stats:'.date('YmdH', $now - 3 * 3600));
+
+        $this->redis->hset($thisHour, 'users:hit', 10);
+        $this->redis->hset($lastHour, 'users:hit', 20);
+        $this->redis->hset($threeHoursAgo, 'users:hit', 30);
+
+        // Lookback 2 hours → only thisHour + lastHour (3-hours-ago excluded).
+        $result = $this->reader->readAllActivity(2);
+        $this->assertSame(30, $result['users']['hit']);
+
+        // Lookback 4 hours → covers all three buckets.
+        $result4h = $this->reader->readAllActivity(4);
+        $this->assertSame(60, $result4h['users']['hit']);
+    }
+
+    public function test_read_ignores_malformed_field_names(): void
+    {
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $this->redis->hset($bucket, 'users:hit', 10);
+        $this->redis->hset($bucket, 'no_colon_at_all', 99);      // missing :action
+        $this->redis->hset($bucket, 'users:unknown_action', 77); // unknown action label
+
+        $result = $this->reader->readAllActivity(1);
+
+        $this->assertSame([
+            'users' => ['hit' => 10, 'miss' => 0, 'invalidate' => 0],
+        ], $result, 'Malformed / unknown-action fields must be silently dropped.');
+    }
+
+    public function test_read_handles_table_names_with_colon_safely(): void
+    {
+        // explode(..., 2) limits to 2 parts so a table name containing colons
+        // ends up labeled with the LAST segment as action — which would then
+        // be filtered out as "unknown action" unless it happens to match
+        // hit/miss/invalidate. Realistic table names don't contain colons, but
+        // this guards us from quietly producing junk if some downstream emits
+        // a weird field.
+        $bucket = $this->redis->prefix('lada:stats:'.date('YmdH'));
+        $this->redis->hset($bucket, 'weird:table:hit', 5);
+
+        $result = $this->reader->readAllActivity(1);
+
+        // First split: table='weird', action='table:hit' → unknown action, dropped.
+        $this->assertSame([], $result);
+    }
+}

--- a/tests/Unit/Stats/StatsReaderTest.php
+++ b/tests/Unit/Stats/StatsReaderTest.php
@@ -96,7 +96,7 @@ class StatsReaderTest extends TestCase
 
     public function test_read_treats_missing_old_buckets_as_zero_contribution(): void
     {
-        // Simulates `stats_lookback_hours` > `bucket_ttl_seconds/3600`: only
+        // Simulates `activity_lookback_hours` > `activity_bucket_ttl_seconds/3600`: only
         // the recent bucket is populated, older keys do not exist (would have
         // expired). HGETALL on a missing key returns empty → 0 contribution.
         $now = time();


### PR DESCRIPTION
## Summary

Adds `php artisan lada-cache:calibrate`, a non-blocking command that
auto-derives per-model TTLs from real Redis access patterns instead of
hand-tuning `config('lada-cache.model_ttls')`.

For each Lada-cached model, the command samples Redis `OBJECT IDLETIME`
across the model's cache keys, computes the P95 idle time, and writes a
calibrated TTL via:

```
calibrated_ttl = max(ceil(P95 * safety_factor), floor(previous_ttl / 2))
```

The `floor(previous_ttl / 2)` term guards against survivor bias: OBJECT
IDLETIME can only sample keys still alive, so without it successive runs
would monotonically shrink TTL toward zero.

Results land in `lada_cache_calibrations` (package migration, published
via `--tag=migrations`) and are consumed by `TtlResolver` between the
`HasLadaTtl` interface and the static `model_ttls` config map.

## TtlResolver chain (updated)

1. `HasLadaTtl::getLadaTtl()` (per-instance override)
2. **`lada_cache_calibrations.calibrated_ttl`** ← new (gated by config flag)
3. `config('lada-cache.model_ttls.<FQCN>')`
4. Global `expiration_time`

Calibration lookups go through `TtlCalibrationRepository`, which caches
the full map in-memory (`Cache::remember`, configurable TTL) so the hot
resolution path never hits DB between calibration runs.

## Safety

- Refuses to run when Redis `maxmemory-policy` is `*-lfu` (IDLETIME
  unsupported under LFU — would calibrate every TTL toward zero).
- Dry-run by default; `--apply` required to mutate the calibrations table.
- Skips models with fewer than `min_samples` data points (including 0).
- `--safety-factor <= 0` aborts with `INVALID` exit code.
- Command's constructor deps are nullable so it stays instantiable when
  Lada is disabled (graceful SUCCESS path matching `FlushCommand`).
- TtlResolver swallows DB errors from the calibration layer and falls
  through to config rather than throwing — boot-time stays decoupled
  from DB availability.

## Performance

- **SSCAN** instead of SMEMBERS for tag-set iteration — avoids blocking
  Redis on multi-million-member sets and bounds client memory.
- **Pipelined `OBJECT IDLETIME`** in batches of 100 — one round-trip
  per batch instead of one per key (~50-100x faster on large caches).
- Both PhpRedis and Predis clients supported; sequential fallback for
  drivers without a pipeline API.

## Config

```env
LADA_CACHE_CALIBRATION_ENABLED=true        # default: false
LADA_CACHE_CALIBRATION_SAFETY_FACTOR=2.0   # P95 multiplier
LADA_CACHE_CALIBRATION_MIN_SAMPLES=50      # skip models with fewer samples
LADA_CACHE_CALIBRATION_CACHE_TTL=300       # in-memory map cache, seconds
```

Recommended cron:

```php
Schedule::command('lada-cache:calibrate --apply')->weekly();
```

## Files

- `src/Calibration/TtlCalibrationRepository.php` (new)
- `src/Console/CalibrateCommand.php` (new)
- `src/Redis.php` — adds `scanKeys()`, `sScanMembers()` generators
- `src/TtlResolver.php` — calibration layer (optional injection)
- `src/LadaCacheServiceProvider.php` — register repo, command, migrations
- `config/lada-cache.php` — `calibration` block + updated `model_ttls` docblock
- `database/migrations/…_create_lada_cache_calibrations_table.php`
- `tests/Unit/Calibration/TtlCalibrationRepositoryTest.php` (7 tests)
- `tests/Console/CalibrateCommandTest.php` (12 tests)
- `README.md` — Auto-calibration section + new Console Command entry

## Test plan

- [x] `php -l` syntax-check on every touched file
- [ ] Reviewer: `composer install && vendor/bin/phpunit --filter=Calibrat`
- [ ] Reviewer: verify migrations publish via `php artisan vendor:publish --tag=migrations`
- [ ] Reviewer: smoke `php artisan lada-cache:calibrate` (dry-run) in a real app with `HasLadaTtl` models

## Dependency note

This PR depends on #152 (HasLadaTtl interface + TtlResolver). It is
branched from `feat/per-model-ttl` to keep the diff minimal — once #152
merges this PR will rebase to a clean diff against `master`.